### PR TITLE
Remove unnecessary describe_subnets calls

### DIFF
--- a/src/bosh_aws_cpi/lib/cloud/aws/aws_provider.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/aws_provider.rb
@@ -19,18 +19,6 @@ module Bosh::AwsCloud
       @ec2_resource = Aws::EC2::Resource.new(client: @ec2_client)
     end
 
-    def aws_accessible?
-      # make an arbitrary HTTP request to ensure we can connect and creds are valid
-      @ec2_resource.subnets.first
-      true
-    rescue Seahorse::Client::NetworkingError => e
-      @logger.error("Failed to connect to AWS: #{e.inspect}\n#{e.backtrace.join("\n")}")
-      err = "Unable to create a connection to AWS. Please check your provided settings: Region '#{@aws_config.region || 'Not provided'}', Endpoint '#{@aws_config.ec2_endpoint || 'Not provided'}'."
-      cloud_error("#{err}\nIaaS Error: #{e.inspect}")
-    rescue Net::OpenTimeout
-      false
-    end
-
     def alb_accessible?
       # make an arbitrary HTTP request to ensure we can connect and creds are valid
       @alb_client.describe_load_balancers(page_size: 1)

--- a/src/bosh_aws_cpi/lib/cloud/aws/cloud_core.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/cloud_core.rb
@@ -28,8 +28,6 @@ module Bosh::AwsCloud
       @ec2_client = @aws_provider.ec2_client
       @ec2_resource = @aws_provider.ec2_resource
 
-      cloud_error('Please make sure the CPI has proper network access to AWS.') unless @aws_provider.aws_accessible?
-
       @az_selector = az_selector
       @volume_manager = volume_manager
 

--- a/src/bosh_aws_cpi/lib/cloud/aws/cloud_v1.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/cloud_v1.rb
@@ -46,8 +46,6 @@ module Bosh::AwsCloud
 
       @cloud_core = CloudCore.new(@config, @logger, @volume_manager, @az_selector, API_VERSION)
 
-      cloud_error('Please make sure the CPI has proper network access to AWS.') unless @aws_provider.aws_accessible?
-
       @instance_manager = InstanceManager.new(@ec2_resource, @logger)
       @instance_type_mapper = InstanceTypeMapper.new
 


### PR DESCRIPTION
### Tracker story
[#166975601](https://www.pivotaltracker.com/story/show/166975601)

### Problem
The AWS CPI makes requests unnecessarily often to the AWS API which leads to `RequestLimitExceeded`.
In particular, the `describe_subnets` API is called too often.
We have observed deployments with several hundreds of instances where `describe_subnets` gets called thousands of times.
Thanks @istvanballok for figuring this out.
This PR serves as discussion how to minimize the number of AWS API calls.

### How to reproduce
Deploy a single instance, e.g. the following deployment using the latest AWS CPI release (v75)
```
---
name: zookeeper

releases:
- name: zookeeper
  version: 0.0.10

stemcells:
- alias: default
  os: ubuntu-xenial
  version: latest

update:
...

instance_groups:
- name: zookeeper
  azs: [z1]
  instances: 1
  jobs:
  - name: zookeeper
    release: zookeeper
    provides:
      conn: {shared: true}
    properties: {}
  - name: status
    release: zookeeper
    properties: {}
  vm_type: default
  stemcell: default
  persistent_disk: 1024
  networks:
  - name: default
```

Grep in the task debug log of the deployment for `describe_subnets`.
In our case it gets called 31 times.

Delete the zookeeper deployment and grep in the task debug log for `describe_subnets`.
In our case it gets called 6 times.

Do the same with the commit of this PR applied.

When deploying, `describe_subnets` is only called once and when deleting the deployment `describe_subnets` is not called at all.

### Discussion
There are potentially 2 solutions:
1. As done in this PR, remove `aws_accessible?` method entirely (got introduced in [this commit](https://github.com/cloudfoundry/bosh-aws-cpi-release/commit/4a07cc37bcdaf8d0bad3a790590c3019007cf762)). Why do we do a dummy request when initializing the CPI to check that we can connect and creds are valid? Why don't we just skip this part and fail later (e.g. in create_vm) in case we can't connect? (We still might want to rescue the `Seahorse::Client::NetworkingError` and `Net::OpenTimeout` errors in the other AWS API requests which is not done in this PR.)
2. In case we really need such a connection check when initializing the CPI, there are still redundant calls to `describe_subnets`. When BOSH invokes the AWS CPI's info method, `describe_subnets` is called 3 times for CPI v1 and 4 times for CPI v2 (since `CloudCore` is initialized often). Also, [this line](https://github.com/cloudfoundry/bosh-aws-cpi-release/blob/cf43ccd8b91d5f33f09bf76dfe8de7a9af3adc75/src/bosh_aws_cpi/lib/cloud/aws/cloud_v1.rb#L49) is redundant.