### PR TITLE
Remove describe_subnets calls

### DIFF
--- a/src/bosh_aws_cpi/lib/cloud/aws/aki_picker.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/aki_picker.rb
@@ -21,22 +21,24 @@ module Bosh::AwsCloud
     private
 
     def fetch_akis(architecture)
-      @resource.images(
-        filters: [
-          {
-            name: 'architecture',
-            values: [architecture],
-          },
-          {
-            name: 'image-type',
-            values: ['kernel'],
-          },
-          {
-            name: 'owner-alias',
-            values: ['amazon'],
-          },
-        ],
-      )
+      AwsProvider.with_aws do
+        @resource.images(
+          filters: [
+            {
+              name: 'architecture',
+              values: [architecture],
+            },
+            {
+              name: 'image-type',
+              values: ['kernel'],
+            },
+            {
+              name: 'owner-alias',
+              values: ['amazon'],
+            },
+          ],
+        )
+      end
     end
 
     def regexp(root_device_name)

--- a/src/bosh_aws_cpi/lib/cloud/aws/availability_zone_selector.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/availability_zone_selector.rb
@@ -18,7 +18,7 @@ module Bosh::AwsCloud
 
     def select_availability_zone(instance_id)
       if instance_id
-        @resource.instance(instance_id).placement.availability_zone
+        AwsProvider.with_aws { @resource.instance(instance_id).placement.availability_zone }
       else
         random_availability_zone
       end
@@ -28,7 +28,9 @@ module Bosh::AwsCloud
 
     def random_availability_zone
       zones = []
-      @resource.client.describe_availability_zones['availability_zones'].each { |az| zones << az['zone_name']}
+      AwsProvider.with_aws do
+        @resource.client.describe_availability_zones['availability_zones'].each { |az| zones << az['zone_name']}
+      end
       zones[Random.rand(zones.size)]
     end
   end

--- a/src/bosh_aws_cpi/lib/cloud/aws/network_configurator.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/network_configurator.rb
@@ -55,15 +55,17 @@ module Bosh::AwsCloud
       end
 
       # AWS accounts that support both EC2-VPC and EC2-Classic platform access explicitly require allocation_id instead of public_ip
-      addresses = ec2.client.describe_addresses(
-        public_ips: [@vip_network.ip],
-        filters: [
-          name: 'domain',
-          values: [
-            'vpc'
+      addresses = AwsProvider.with_aws do
+        ec2.client.describe_addresses(
+          public_ips: [@vip_network.ip],
+          filters: [
+            name: 'domain',
+            values: [
+              'vpc'
+            ]
           ]
-        ]
-      ).addresses
+        ).addresses
+      end
       found_address = addresses.first
       cloud_error("Elastic IP with VPC scope not found with address '#{@vip_network.ip}'") if found_address.nil?
 
@@ -78,9 +80,11 @@ module Bosh::AwsCloud
       # API call will fail in that case.
 
       errors = [Aws::EC2::Errors::IncorrectInstanceState, Aws::EC2::Errors::InvalidInstanceID]
-      Bosh::Common.retryable(tries: 10, sleep: 1, on: errors) do
-        ec2.client.associate_address(instance_id: instance.id, allocation_id: allocation_id)
-        true # need to return true to end the retries
+      AwsProvider.with_aws do
+        Bosh::Common.retryable(tries: 10, sleep: 1, on: errors) do
+          ec2.client.associate_address(instance_id: instance.id, allocation_id: allocation_id)
+          true # need to return true to end the retries
+        end
       end
     end
   end

--- a/src/bosh_aws_cpi/lib/cloud/aws/sdk_helpers/volume_attachment.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/sdk_helpers/volume_attachment.rb
@@ -10,8 +10,8 @@ module Bosh::AwsCloud::SdkHelpers
     attr_reader :device
 
     def initialize(attachment, resource_client)
-      @volume = resource_client.volume(attachment.volume_id)
-      @instance = resource_client.instance(attachment.instance_id)
+      @volume = AwsProvider.with_aws { resource_client.volume(attachment.volume_id) }
+      @instance = AwsProvider.with_aws { resource_client.instance(attachment.instance_id) }
       @device = attachment.device
     end
 

--- a/src/bosh_aws_cpi/lib/cloud/aws/security_group_mapper.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/security_group_mapper.rb
@@ -38,7 +38,7 @@ module Bosh::AwsCloud
 
     def existing_groups_for_subnet(subnet_id)
       # NOTE: We call #to_a to ensure the EC2 client makes a single request.
-      @ec2_resource.subnet(subnet_id).vpc.security_groups.to_a
+      AwsProvider.with_aws { @ec2_resource.subnet(subnet_id).vpc.security_groups.to_a }
     end
 
     def is_id?(input)

--- a/src/bosh_aws_cpi/lib/cloud/aws/stemcell.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/stemcell.rb
@@ -56,7 +56,7 @@ module Bosh::AwsCloud
     def delete_snapshots
       snapshots.each do |id|
         logger.info("cleaning up snapshot '#{id}'")
-        snapshot = @resource.snapshot(id)
+        snapshot = AwsProvider.with_aws { @resource.snapshot(id) }
         snapshot.delete
       end
     end

--- a/src/bosh_aws_cpi/lib/cloud/aws/stemcell_creator.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/stemcell_creator.rb
@@ -23,7 +23,14 @@ module Bosh::AwsCloud
 
       # the top-level ec2 class' ImageCollection.create does not support the full set of params
       params = image_params(snapshot.id)
-      image = resource.images(filters: [{name: 'image-id', values: [resource.client.register_image(params).image_id]}]).first
+      image = AwsProvider.with_aws do
+        resource.images(
+          filters: [{
+            name: 'image-id',
+            values: [resource.client.register_image(params).image_id]
+          }]
+        ).first
+      end
       ResourceWait.for_image(image: image, state: 'available')
 
       TagManager.tag(image, 'Name', params[:description]) if params[:description]

--- a/src/bosh_aws_cpi/lib/cloud/aws/stemcell_finder.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/stemcell_finder.rb
@@ -6,10 +6,12 @@ module Bosh::AwsCloud
     def self.find_by_id(client, id)
       regex = / light$/
 
-      if id =~ regex
-        LightStemcell.new(Stemcell.find(client, id.sub(regex, '')), Bosh::Clouds::Config.logger)
-      else
-        Stemcell.find(client, id)
+      AwsProvider.with_aws do
+        if id =~ regex
+          LightStemcell.new(Stemcell.find(client, id.sub(regex, '')), Bosh::Clouds::Config.logger)
+        else
+          Stemcell.find(client, id)
+        end
       end
     end
   end

--- a/src/bosh_aws_cpi/spec/integration/helpers/ec2_helper.rb
+++ b/src/bosh_aws_cpi/spec/integration/helpers/ec2_helper.rb
@@ -37,7 +37,7 @@ module IntegrationHelpers
   end
 
   def get_security_group_ids
-    security_groups = @ec2.subnet(@subnet_id).vpc.security_groups
+    security_groups = AwsProvider.with_aws { @ec2.subnet(@subnet_id).vpc.security_groups }
     security_groups.map { |sg| sg.id }
   end
 end


### PR DESCRIPTION
Removing unnecessary infrastrucutre call to prevent `Request Limit Exceeded`
errors.
The describe_subnets call was used to catch Networking and Timeout errors early.
We are now catching these errors on every infrastructure request rather
than checking only once with an arbitrary infrastructure request.

[#167365982](https://www.pivotaltracker.com/story/show/167365982)

Co-authored-by: Max Becker <max.becker@sap.com>
Co-authored-by: Sebastian Heid <sebastian.heid@sap.com>