### PR TITLE
Fix Spot Instance creation with tags

### DIFF
--- a/src/bosh_aws_cpi/lib/cloud/aws/spot_manager.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/spot_manager.rb
@@ -12,6 +12,10 @@ module Bosh::AwsCloud
     end
 
     def create(launch_specification, spot_bid_price)
+      # Spot instances can't send tag_specifications with the launch specification. Otherwise this
+      # call bombs
+      launch_specification.delete(:tag_specifications)
+
       spot_request_spec = {
         spot_price: "#{spot_bid_price}",
         instance_count: 1,


### PR DESCRIPTION
Spot instances cannot be created with tags in the same operation. If the
`launch_specification` contains `tags` then the call will fail. This
addresses that issue by filtering them out.