### PR TITLE
Add a new API method resize_disk

### DIFF
--- a/src/bosh_aws_cpi/lib/cloud/aws.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws.rb
@@ -50,6 +50,7 @@ require 'cloud/aws/instance_type_mapper'
 require 'cloud/aws/classic_lb'
 require 'cloud/aws/lb_target_group'
 require 'cloud/aws/sdk_helpers/volume_attachment'
+require 'cloud/aws/sdk_helpers/volume_modification'
 require 'cloud/aws/sdk_helpers/volume_manager'
 
 module Bosh

--- a/src/bosh_aws_cpi/lib/cloud/aws/cloud_v1.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/cloud_v1.rb
@@ -233,6 +233,12 @@ module Bosh::AwsCloud
       end
     end
 
+    def resize_disk(disk_id, new_size)
+      with_thread_name("resize_disk(#{disk_id}, #{new_size})") do
+        @cloud_core.resize_disk(disk_id, new_size)
+      end
+    end
+
     # Attach an EBS volume to an EC2 instance
     # @param [String] instance_id EC2 instance id of the virtual machine to attach the disk to
     # @param [String] disk_id EBS volume id of the disk to attach

--- a/src/bosh_aws_cpi/lib/cloud/aws/sdk_helpers/volume_manager.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/sdk_helpers/volume_manager.rb
@@ -16,6 +16,14 @@ module Bosh::AwsCloud
       volume
     end
 
+    def extend_ebs_volume(volume, new_size)
+      resp = @ec2_client.modify_volume(volume_id: volume.id, size: new_size)
+
+      volume_modification = SdkHelpers::VolumeModification.new(volume, resp.volume_modification, @ec2_client)
+      @logger.info("Extending volume `#{volume.id}'")
+      ResourceWait.for_volume_modification(volume_modification: volume_modification, state: 'completed')
+    end
+
     def delete_ebs_volume(volume, fast_path_delete = false)
       @logger.info("Deleting volume `#{volume.id}'")
 

--- a/src/bosh_aws_cpi/lib/cloud/aws/sdk_helpers/volume_modification.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/sdk_helpers/volume_modification.rb
@@ -1,0 +1,32 @@
+module Bosh::AwsCloud::SdkHelpers
+
+   class VolumeModification
+
+    attr_reader :volume
+    attr_reader :resource_client
+    attr_reader :modification
+
+    def initialize(volume, modification, resource_client)
+      @volume = volume
+      @resource_client = resource_client
+      @modification = modification
+    end
+
+    def state
+      @modification.modification_state
+    end
+
+    def data
+      @volume.data
+    end
+
+    def reload
+      resp = @resource_client.describe_volumes_modifications(volume_ids: [ @volume.id])
+      if resp.volumes_modifications.empty?
+        raise Aws::EC2::Errors::InvalidVolumeNotFound.new(nil, "Unable to find disk modification for volume '#{@volume.id}'")
+      end
+      @modification = resp.volumes_modifications[0]
+    end
+  end
+
+end

--- a/src/bosh_aws_cpi/spec/integration/manual_network_spec.rb
+++ b/src/bosh_aws_cpi/spec/integration/manual_network_spec.rb
@@ -519,6 +519,20 @@ describe Bosh::AwsCloud::CloudV1 do
       end
     end
 
+    it 'can resize a disk' do
+      begin
+        volume_id = @cpi.create_disk(2048, {})
+        @cpi.resize_disk(volume_id, 4096)
+        expect(volume_id).not_to be_nil
+        expect(@cpi.has_disk?(volume_id)).to be(true)
+
+        volume = @cpi.ec2_resource.volume(volume_id)
+        expect(volume.size).to eq(4)
+      ensure
+        @cpi.delete_disk(volume_id) if volume_id
+      end
+    end
+
     context 'when ephemeral_disk properties are specified' do
       let(:vm_type) do
         {

--- a/src/bosh_aws_cpi/spec/unit/resize_disk_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/resize_disk_spec.rb
@@ -1,0 +1,83 @@
+require "spec_helper"
+
+describe Bosh::AwsCloud::CloudV1, "resize_disk" do
+  let(:volume_manager) { instance_double(Bosh::AwsCloud::VolumeManager) }
+  let(:volume) { instance_double(Aws::EC2::Volume, :id => 'disk-id') }
+  let(:volume_resp) { instance_double(Aws::EC2::Types::ModifyVolumeResult, :volume_modification => {modification_state: 'completed'}) }
+
+  before do
+    @cloud = mock_cloud do |_ec2|
+      @ec2 = _ec2
+      allow(@ec2).to receive(:config).and_return('fake-config')
+      allow(@ec2).to receive(:volume).with("disk-id").and_return(volume)
+    end
+    allow(volume).to receive(:size).and_return(2)
+    allow(volume).to receive(:attachments).and_return([])
+    allow(@ec2.client).to receive(:modify_volume).and_return(volume_resp)
+    modification = instance_double(Bosh::AwsCloud::SdkHelpers::VolumeModification, :state => 'completed')
+    allow(Bosh::AwsCloud::SdkHelpers::VolumeModification).to receive(:new).with(volume, volume_resp.volume_modification, @ec2.client).and_return(modification)
+    allow(Bosh::AwsCloud::ResourceWait).to receive(:for_volume_modification).with(volume_modification: modification, state: 'completed')
+  end
+
+
+  it 'uses the AWS endpoint to resize a disk' do
+    allow(Bosh::Clouds::Config.logger).to receive(:info)
+    return_value = @cloud.resize_disk('disk-id', 4096)
+
+    expect(return_value).to eq(nil)
+
+    expect(@ec2.client).to have_received(:modify_volume).with(volume_id: 'disk-id',size: 4)
+    expect(Bosh::Clouds::Config.logger).to have_received(:info).with('Disk disk-id resized from 2 GiB to 4 GiB')
+  end
+
+  context 'when trying to resize to the same disk size' do
+    it 'does not call extend on disk and writes to the log' do
+      allow(Bosh::Clouds::Config.logger).to receive(:info)
+
+      @cloud.resize_disk('disk-id', 2048)
+
+      expect(Bosh::Clouds::Config.logger).to have_received(:info).with('Skipping resize of disk disk-id because current value 2 GiB is equal new value 2 GiB')
+    end
+  end
+
+  context 'when trying to resize disk to a new size with an not even size in MiB' do
+    it 'does not call extend on disk and writes to the log' do
+      allow(volume).to receive(:extend)
+      allow(Bosh::Clouds::Config.logger).to receive(:info)
+
+      @cloud.resize_disk('disk-id', 4097)
+
+      expect(@ec2.client).to have_received(:modify_volume).with(volume_id: 'disk-id',size: 5)
+      expect(Bosh::Clouds::Config.logger).to have_received(:info).with('Disk disk-id resized from 2 GiB to 5 GiB')
+    end
+  end
+
+  context 'when trying to resize a non existing disk' do
+    it 'fails' do
+      allow(@ec2).to receive(:volume).with('non-existing-disk-id').and_return(nil)
+      expect {
+        @cloud.resize_disk('non-existing-disk-id', 1024)
+      }.to raise_error(Bosh::Clouds::CloudError, 'Cannot resize volume because volume with non-existing-disk-id not found')
+    end
+  end
+
+  context 'when trying to resize to a smaller disk' do
+    it 'fails' do
+      expect {
+        @cloud.resize_disk('disk-id', 1024)
+      }.to raise_error(Bosh::Clouds::CloudError, 'Cannot resize volume to a smaller size from 2 GiB to 1 GiB')
+    end
+  end
+
+  context 'when volume is still attached' do
+    before do
+      allow(volume).to receive(:attachments).and_return([{}])
+    end
+
+    it 'fails' do
+      expect {
+        @cloud.resize_disk('disk-id', 4096)
+      }.to raise_error(Bosh::Clouds::CloudError, "Cannot resize volume 'disk-id' it still has 1 attachment(s)")
+    end
+  end
+end

--- a/src/bosh_aws_cpi/spec/unit/resize_disk_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/resize_disk_spec.rb
@@ -41,7 +41,7 @@ describe Bosh::AwsCloud::CloudV1, "resize_disk" do
   end
 
   context 'when trying to resize disk to a new size with an not even size in MiB' do
-    it 'does not call extend on disk and writes to the log' do
+    it 'does call extend on disk with rounding up to the next higher number and writes to the log' do
       allow(volume).to receive(:extend)
       allow(Bosh::Clouds::Config.logger).to receive(:info)
 


### PR DESCRIPTION
* this change allows to resize volumes using the AWS API
* the change is analogous to the change inside the BOSH Openstack CPI: https://github.com/cloudfoundry/bosh-openstack-cpi-release/commit/d081938852ecae502c0ba285020996a4a0c0d01d
* to use this feature the bosh director configuration enable_cpi_resize_disk needs to be enabled