### PR TITLE
`sudo` the one executable, not the entire script

### DIFF
--- a/src/bosh_aws_cpi/bin/stemcell-copy
+++ b/src/bosh_aws_cpi/bin/stemcell-copy
@@ -1,8 +1,7 @@
 #!/bin/bash
 #
-# This script runs as root through sudo without the need for a password,
-# so it needs to make sure it can't be abused.
-#
+# The user running this script requires password-less sudo privileges
+# to copy the disk image to the raw disk device
 
 set -euo pipefail
 
@@ -23,4 +22,4 @@ if [[ ! -b ${OUTPUT_PATH} ]]; then
 fi
 
 # copy image to block device with 1 MB block size
-tar -xzf ${IMAGE} -O root.img | dd bs=1M of=${OUTPUT_PATH}
+tar -xzf ${IMAGE} -O root.img | sudo -n dd bs=1M of=${OUTPUT_PATH}

--- a/src/bosh_aws_cpi/lib/cloud/aws/stemcell_creator.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/stemcell_creator.rb
@@ -33,12 +33,11 @@ module Bosh::AwsCloud
 
     private
 
-    # This method tries to execute the helper script stemcell-copy
-    # as root using sudo, since it needs to write to the device_path.
-    # If stemcell-copy isn't available, it falls back to writing directly
-    # to the device, which is used in the micro bosh deployer.
+    # This method tries to execute the helper script stemcell-copy.
+    # If stemcell-copy isn't available in the PATH, it falls back to
+    # an internal version that untars the stemcell and pipes it to `dd`.
     # The stemcell-copy script must be in the PATH of the user running
-    # the director, and needs sudo privileges to execute without
+    # the script, and the user needs sudo privileges to execute without
     # password.
     #
     def copy_root_image
@@ -48,11 +47,11 @@ module Bosh::AwsCloud
         logger.debug('copying stemcell using stemcell-copy script')
         # note that is is a potentially dangerous operation, but as the
         # stemcell-copy script sets PATH to a sane value this is safe
-        command = "sudo -n #{stemcell_copy} #{image_path} #{device_path} 2>&1"
+        command = "#{stemcell_copy} #{image_path} #{device_path} 2>&1"
       else
         logger.info('falling back to using included copy stemcell')
         included_stemcell_copy = File.expand_path('../../../../bin/stemcell-copy', __FILE__)
-        command = "sudo -n #{included_stemcell_copy} #{image_path} #{device_path} 2>&1"
+        command = "#{included_stemcell_copy} #{image_path} #{device_path} 2>&1"
       end
 
       result = sh(command)


### PR DESCRIPTION
Instead of running the entire `stemcell-copy` as root, which is unnecessary, we restrict root privileges to the single `dd` command.

This lays the groundwork for allowing non-privileged users to run `bosh create-env` without root privileges (by moving `sudo` out of the CPI and into a helper script which can be swapped in for a different, sudo-less, helper script).