### PR TITLE
Allow to configure throughput for gp3 volumes

### DIFF
--- a/src/bosh_aws_cpi/lib/cloud/aws/cloud_props.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/cloud_props.rb
@@ -63,13 +63,14 @@ module Bosh::AwsCloud
   end
 
   class DiskCloudProps
-    attr_reader :type, :iops, :encrypted, :kms_key_arn
+    attr_reader :type, :iops, :throughput, :encrypted, :kms_key_arn
 
     # @param [Hash] cloud_properties
     # @param [Bosh::AwsCloud::Config] global_config
     def initialize(cloud_properties, global_config)
       @type = cloud_properties['type']
       @iops = cloud_properties['iops']
+      @throughput = cloud_properties['throughput']
 
       @encrypted = global_config.aws.encrypted
       @encrypted = !!cloud_properties['encrypted'] if cloud_properties.key?('encrypted')

--- a/src/bosh_aws_cpi/lib/cloud/aws/cloud_v1.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/cloud_v1.rb
@@ -203,6 +203,7 @@ module Bosh::AwsCloud
           size: size,
           type: props.type,
           iops: props.iops,
+          throughput: props.throughput,
           az: @az_selector.select_availability_zone(instance_id),
           encrypted: props.encrypted,
           kms_key_arn: props.kms_key_arn

--- a/src/bosh_aws_cpi/lib/cloud/aws/volume_properties.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/volume_properties.rb
@@ -9,6 +9,7 @@ module Bosh
         @size = options[:size] || 0
         @type = options[:type] || 'gp2'
         @iops = options[:iops]
+        @throughput = options[:throughput]
         @az = options[:az]
         @kms_key_arn = options[:kms_key_arn]
         @encrypted = options[:encrypted] || false
@@ -39,6 +40,7 @@ module Bosh
         }
 
         output[:iops] = @iops if @iops
+        output[:throughput] = @throughput if @throughput
         output[:kms_key_id] = @kms_key_arn if @kms_key_arn
         unless @tags.empty?
           output[:tag_specifications] = [


### PR DESCRIPTION
according to API docs
https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/EC2/Client.html#create_volume-instance_method
it should be possible to specify desired throughput for a gp3 volume to be
created. Also see AWS docs [1]

Optionally allow throughput to be specified as part of
the cloud properties for a disk type.

TODO add tests
TODO this should only be possible if the disk type is 'gp3'

[1] https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/create-volume.html