### PR TITLE
Increase timeout for volume modification

### DIFF
--- a/src/bosh_aws_cpi/lib/cloud/aws/resource_wait.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/resource_wait.rb
@@ -85,7 +85,7 @@ module Bosh::AwsCloud
       end
       description = "volume modification of %s current state %s" % [volume_modification.volume.id, volume_modification.state]
 
-      new.for_resource(resource: volume_modification, errors: ignored_errors, target_state: target_state, description: description) do |current_state|
+      new.for_resource(resource: volume_modification, errors: ignored_errors, target_state: target_state, description: description, tries: DEFAULT_TRIES * 4) do |current_state|
         current_state == target_state
       end
 


### PR DESCRIPTION
Resizing a disk e.g. from 2TB to 4TB can easily
take an hour or more, so we increase the timeout
for this operation to around 100 minutes
(4 times the default timeout of around 25 minutes)

Fixes issue #116 