### PR TITLE
Make agent credentials unnecessary for accessing a DAV blobstore with signed URLs enabled

### DIFF
--- a/jobs/aws_cpi/spec
+++ b/jobs/aws_cpi/spec
@@ -145,9 +145,9 @@ properties:
     description: Port of blobstore server used by dav blobstore plugin
     default: 25250
   blobstore.agent.user:
-    description: Username agent uses to connect to blobstore used by dav blobstore plugin
+    description: Username agent uses to connect to blobstore used by dav blobstore plugin (Optional)
   blobstore.agent.password:
-    description: Password agent uses to connect to blobstore used by dav blobstore plugin
+    description: Password agent uses to connect to blobstore used by dav blobstore plugin (Required only when user is provided)
 
   agent.mbus:
     description: Agent mbus

--- a/jobs/aws_cpi/templates/cpi.json.erb
+++ b/jobs/aws_cpi/templates/cpi.json.erb
@@ -55,7 +55,7 @@ params["cloud"]["properties"]["aws"]["region"] = p('aws.region')
 
 agent_params = params["cloud"]["properties"]["agent"]
 
-blobstore_defined = p('blobstore.provider') != 'dav' || !p(['blobstore.agent.user', 'blobstore.agent.password', 'agent.blobstore.address', 'blobstore.address'], nil).nil?
+blobstore_defined = p('blobstore.provider') != 'dav' || !p(['blobstore.agent.user', 'agent.blobstore.address', 'blobstore.address'], nil).nil?
 if blobstore_defined
   agent_params["blobstore"] = {
        "provider" => p('blobstore.provider'),
@@ -92,10 +92,13 @@ if blobstore_defined
     }
   else
     blobstore["options"] = {
-      "endpoint" => "http://#{p(['agent.blobstore.address', 'blobstore.address'])}:#{p('blobstore.port')}",
-      "user" => p('blobstore.agent.user'),
-      "password" => p('blobstore.agent.password')
+      "endpoint" => "http://#{p(['agent.blobstore.address', 'blobstore.address'])}:#{p('blobstore.port')}"
     }
+
+    if_p('blobstore.agent.user') do
+      blobstore["options"]["user"] = p('blobstore.agent.user')
+      blobstore["options"]["password"] = p('blobstore.agent.password')
+    end
   end
 end
 

--- a/src/bosh_aws_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'json'
+require 'yaml'
 
 describe 'cpi.json.erb' do
   let(:cpi_specification_file) { File.absolute_path(File.join(jobs_root, 'aws_cpi/spec')) }
@@ -187,6 +188,27 @@ describe 'cpi.json.erb' do
     it 'uses the value set' do
       manifest['properties']['aws']['default_iam_instance_profile'] = 'some_default_instance_profile'
       expect(subject['cloud']['properties']['aws']['default_iam_instance_profile']).to eq('some_default_instance_profile')
+    end
+  end
+
+  context 'when using a dav blobstore' do
+    let(:rendered_blobstore) { subject['cloud']['properties']['agent']['blobstore'] }
+
+    it 'renders agent user/password for accessing blobstore' do
+        expect(rendered_blobstore['options']['user']).to eq('agent')
+        expect(rendered_blobstore['options']['password']).to eq('agent-password')
+    end
+
+    context 'when enabling signed URLs' do
+      before do
+        manifest['properties']['blobstore']['agent'].delete('user')
+        manifest['properties']['blobstore']['agent'].delete('password')
+      end
+
+      it 'does not render agent user/password for accessing blobstore' do
+        expect(rendered_blobstore['options']['user']).to be_nil
+        expect(rendered_blobstore['options']['password']).to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
When signed URLs are enabled, no agent user/password should be specified in Director's deployment manifest for CPIs config.

This PR relates to previous work in:
- cloudfoundry/bosh#2327
- cloudfoundry/bosh-deployment#423
- cloudfoundry/docs-bosh#755
- cloudfoundry/bosh-davcli#12

Here we make the properties `blobstore.agent.{user,password}` optional.
ERB unit tests have been updated to provide proper coverage for the new use-case.
… and fixed so that they can be run individually with:
```
cd src/bosh_aws_cpi && bundle exec rspec spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
```

Co-Authored-By: @OliverMautschke