### PR TITLE
Configurable timeout factor for IaaS-native disk resize

### DIFF
--- a/jobs/aws_cpi/spec
+++ b/jobs/aws_cpi/spec
@@ -45,7 +45,11 @@ properties:
     description: "AWS ELB service endpoint, without protocol/scheme (Optional: default endpoint will be constructed from region if not specified)"
     example: elasticloadbalancing.us-east-1.amazonaws.com
   aws.max_retries:
-    description: The maximum number of times AWS service errors and throttling errors should be retried. There is an exponential backoff in between retries, so the more retries the longer it can take to fail.
+    description: |
+      The maximum number of times AWS service errors and throttling errors
+      should be retried. There is an exponential backoff in between retries,
+      so the more retries the longer it can take to fail. This only applies
+      to the AWS client passing calls to the AWS API.
     default: 8
   aws.connection_options.ca_cert:
     description: All required custom CA certificates
@@ -60,6 +64,14 @@ properties:
     description: Encrypts all instances' volumes with the given KMS key. (aws.encrypted) should be true
     example: arn:aws:kms:us-east-1:XXXXXX:key/e1c1f008-779b-4ebe-8116-0a34b77747dd
     default: null
+  aws.extend_ebs_volume.wait_time_factor:
+    description: |
+      Default wait time for AWS operations is ≈25 minutes. When growing
+      persistent disk size above 4TB, this maximum wait time may need to be
+      increased. The value here is a factor of the base ≈25 minutes wait
+      time. For example a factor of 3 would lead to a wait time of ≈75
+      minutes.
+    default: 4
 
   registry.username:
     description: User to access the Registry

--- a/jobs/aws_cpi/templates/cpi.json.erb
+++ b/jobs/aws_cpi/templates/cpi.json.erb
@@ -13,6 +13,7 @@ params = {
         "default_key_name" => p('aws.default_key_name'),
         "default_security_groups" => p('aws.default_security_groups'),
         "max_retries" => p('aws.max_retries'),
+        "extend_ebs_volume_wait_time_factor" => p('aws.extend_ebs_volume.wait_time_factor'),
         "encrypted" => p('aws.encrypted'),
         "kms_key_arn" => p('aws.kms_key_arn', nil)
       },

--- a/src/bosh_aws_cpi/lib/cloud/aws/cloud_v1.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/cloud_v1.rb
@@ -42,7 +42,7 @@ module Bosh::AwsCloud
       @ec2_client = @aws_provider.ec2_client
       @ec2_resource = @aws_provider.ec2_resource
       @az_selector = AvailabilityZoneSelector.new(@ec2_resource)
-      @volume_manager = Bosh::AwsCloud::VolumeManager.new(@logger, @aws_provider)
+      @volume_manager = Bosh::AwsCloud::VolumeManager.new(@config.aws, @logger, @aws_provider)
 
       @cloud_core = CloudCore.new(@config, @logger, @volume_manager, @az_selector, API_VERSION)
 

--- a/src/bosh_aws_cpi/lib/cloud/aws/config.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/config.rb
@@ -1,6 +1,7 @@
 module Bosh::AwsCloud
   class AwsConfig
-    attr_reader :max_retries, :credentials, :region, :ec2_endpoint, :elb_endpoint, :stemcell
+    attr_reader :max_retries, :extend_ebs_volume_wait_time_factor, :credentials
+    attr_reader :region, :ec2_endpoint, :elb_endpoint, :stemcell
     attr_reader :access_key_id, :secret_access_key, :default_key_name, :encrypted, :kms_key_arn
     attr_reader :default_iam_instance_profile, :default_security_groups, :metadata_options
 
@@ -11,6 +12,7 @@ module Bosh::AwsCloud
       @config = aws_config_hash
 
       @max_retries = @config['max_retries']
+      @extend_ebs_volume_wait_time_factor = @config['extend_ebs_volume_wait_time_factor']
 
       @region = @config['region']
       @ec2_endpoint = @config['ec2_endpoint']

--- a/src/bosh_aws_cpi/lib/cloud/aws/sdk_helpers/volume_manager.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/sdk_helpers/volume_manager.rb
@@ -23,8 +23,15 @@ module Bosh::AwsCloud
 
       volume_modification = SdkHelpers::VolumeModification.new(volume, resp.volume_modification, @ec2_client)
       @logger.info("Extending volume `#{volume.id}'")
-      ResourceWait.for_volume_modification(volume_modification: volume_modification, state: 'completed',
-                                           wait_time_factor: @aws_config.extend_ebs_volume_wait_time_factor)
+
+      args = {
+        volume_modification: volume_modification,
+        state: 'completed'
+      }
+      unless @aws_config.extend_ebs_volume_wait_time_factor.nil?
+        args[:wait_time_factor] = @aws_config.extend_ebs_volume_wait_time_factor
+      end
+      ResourceWait.for_volume_modification(args)
     end
 
     def delete_ebs_volume(volume, fast_path_delete = false)

--- a/src/bosh_aws_cpi/lib/cloud/aws/sdk_helpers/volume_manager.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/sdk_helpers/volume_manager.rb
@@ -1,6 +1,8 @@
 module Bosh::AwsCloud
   class VolumeManager
-    def initialize(logger, aws_provider)
+
+    def initialize(aws_config, logger, aws_provider)
+      @aws_config = aws_config
       @logger = logger
       @ec2_resource = aws_provider.ec2_resource
       @ec2_client = aws_provider.ec2_client
@@ -21,7 +23,8 @@ module Bosh::AwsCloud
 
       volume_modification = SdkHelpers::VolumeModification.new(volume, resp.volume_modification, @ec2_client)
       @logger.info("Extending volume `#{volume.id}'")
-      ResourceWait.for_volume_modification(volume_modification: volume_modification, state: 'completed')
+      ResourceWait.for_volume_modification(volume_modification: volume_modification, state: 'completed',
+                                           wait_time_factor: @aws_config.extend_ebs_volume_wait_time_factor)
     end
 
     def delete_ebs_volume(volume, fast_path_delete = false)

--- a/src/bosh_aws_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -59,6 +59,7 @@ describe 'cpi.json.erb' do
             'default_security_groups'=>['security_group_1'],
             'region' => 'moon',
             'max_retries' => 8,
+            'extend_ebs_volume_wait_time_factor' => 4,
             'encrypted' => false,
             'kms_key_arn' => nil
           },
@@ -188,6 +189,17 @@ describe 'cpi.json.erb' do
     it 'uses the value set' do
       manifest['properties']['aws']['default_iam_instance_profile'] = 'some_default_instance_profile'
       expect(subject['cloud']['properties']['aws']['default_iam_instance_profile']).to eq('some_default_instance_profile')
+    end
+  end
+
+  context 'given a customized extend_ebs_volume_wait_time_factor' do
+    before do
+      manifest['properties']['aws']['extend_ebs_volume'] ||= {}
+      manifest['properties']['aws']['extend_ebs_volume']['wait_time_factor'] = 77
+    end
+
+    it 'uses the value set' do
+      expect(subject['cloud']['properties']['aws']['extend_ebs_volume_wait_time_factor']).to eq(77)
     end
   end
 

--- a/src/bosh_aws_cpi/spec/unit/resize_disk_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/resize_disk_spec.rb
@@ -17,8 +17,7 @@ describe Bosh::AwsCloud::CloudV1, "resize_disk" do
     modification = instance_double(Bosh::AwsCloud::SdkHelpers::VolumeModification, :state => 'completed')
     allow(Bosh::AwsCloud::SdkHelpers::VolumeModification).to receive(:new).with(volume, volume_resp.volume_modification, @ec2.client).and_return(modification)
     allow(Bosh::AwsCloud::ResourceWait).to receive(:for_volume_modification)
-      .with(volume_modification: modification, state: 'completed',
-            wait_time_factor: nil)
+      .with(volume_modification: modification, state: 'completed')
   end
 
 

--- a/src/bosh_aws_cpi/spec/unit/resize_disk_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/resize_disk_spec.rb
@@ -16,7 +16,9 @@ describe Bosh::AwsCloud::CloudV1, "resize_disk" do
     allow(@ec2.client).to receive(:modify_volume).and_return(volume_resp)
     modification = instance_double(Bosh::AwsCloud::SdkHelpers::VolumeModification, :state => 'completed')
     allow(Bosh::AwsCloud::SdkHelpers::VolumeModification).to receive(:new).with(volume, volume_resp.volume_modification, @ec2.client).and_return(modification)
-    allow(Bosh::AwsCloud::ResourceWait).to receive(:for_volume_modification).with(volume_modification: modification, state: 'completed')
+    allow(Bosh::AwsCloud::ResourceWait).to receive(:for_volume_modification)
+      .with(volume_modification: modification, state: 'completed',
+            wait_time_factor: nil)
   end
 
 

--- a/src/bosh_aws_cpi/spec/unit/volume_manager_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/volume_manager_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+module Bosh::AwsCloud
+
+  describe :VolumeManager do
+    let(:volume_manager) { VolumeManager.new(config.aws, logger, aws_provider) }
+
+    let(:config) { Bosh::AwsCloud::Config.build(cloud_options.dup.freeze) }
+    let(:logger) { double }
+    let(:aws_provider) { Bosh::AwsCloud::AwsProvider.new(config.aws, logger) }
+
+    let(:cloud_options) { mock_cloud_options['properties'] }
+
+    let(:ec2_resource) { instance_double(Aws::EC2::Resource) }
+    let(:ec2_client) { instance_double(Aws::EC2::Client) }
+
+    before do
+      allow(aws_provider).to receive(:ec2_resource).and_return(ec2_resource)
+      allow(aws_provider).to receive(:ec2_client).and_return(ec2_client)
+    end
+
+    describe '#extend_ebs_volume' do
+      let(:mock_volume) { double }
+      let(:mock_resp) { double }
+      let(:new_size) { 2048000 }
+
+      before do
+        allow(mock_volume).to receive(:id).and_return(1234)
+        allow(ec2_client)
+          .to receive(:modify_volume)
+          .with(volume_id: 1234, size: new_size)
+          .and_return(mock_resp)
+        allow(mock_resp).to receive(:volume_modification)
+        allow(SdkHelpers::VolumeModification).to receive(:new)
+        allow(logger).to receive(:info)
+        allow(ResourceWait).to receive(:for_volume_modification)
+      end
+
+      context 'when wait_time_factor is not configured' do
+        it 'should apply a default wait_time_factor' do
+          expect(volume_manager).not_to be_nil
+          ret = volume_manager.extend_ebs_volume(mock_volume, new_size)
+
+          expect(ec2_client).to have_received(:modify_volume).with(volume_id: 1234, size: new_size)
+          expect(SdkHelpers::VolumeModification).to have_received(:new)
+          expect(logger).to have_received(:info)
+
+          expect(ResourceWait)
+            .to have_received(:for_volume_modification)
+            .with(hash_including(wait_time_factor: nil))
+        end
+      end
+
+      context 'when wait_time_factor is configured' do
+        let(:cloud_options) {
+          props = mock_cloud_options['properties']
+          props['aws']['extend_ebs_volume_wait_time_factor'] = wait_time_factor
+          props
+        }
+        let(:wait_time_factor) { 7 }
+
+        it 'should apply the configured wait_time_factor' do
+          volume_manager.extend_ebs_volume(mock_volume, new_size)
+
+          expect(ec2_client).to have_received(:modify_volume).with(volume_id: 1234, size: new_size)
+          expect(SdkHelpers::VolumeModification).to have_received(:new)
+          expect(logger).to have_received(:info)
+
+          expect(ResourceWait)
+            .to have_received(:for_volume_modification)
+            .with(hash_including(wait_time_factor: wait_time_factor))
+        end
+      end
+    end
+  end
+end

--- a/src/bosh_aws_cpi/spec/unit/volume_manager_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/volume_manager_spec.rb
@@ -47,7 +47,7 @@ module Bosh::AwsCloud
 
           expect(ResourceWait)
             .to have_received(:for_volume_modification)
-            .with(hash_including(wait_time_factor: nil))
+            .with(hash_excluding(:wait_time_factor))
         end
       end
 


### PR DESCRIPTION
As announced in #116 few days ago, here is a patch implementing a configurable timeout scale factor for IaaS-native disk resize operations.

As discussed, increasing the timeout is useful for successfully resizing very large disks.

This patch here overrides the hardcoded factor of `4` that has already been merged with #117, and the value of `4` is kept as the default.
