### PR TITLE
Fast AWS-native disk resize

### DIFF
--- a/jobs/aws_cpi/spec
+++ b/jobs/aws_cpi/spec
@@ -64,14 +64,6 @@ properties:
     description: Encrypts all instances' volumes with the given KMS key. (aws.encrypted) should be true
     example: arn:aws:kms:us-east-1:XXXXXX:key/e1c1f008-779b-4ebe-8116-0a34b77747dd
     default: null
-  aws.extend_ebs_volume.wait_time_factor:
-    description: |
-      Default wait time for AWS operations is ≈25 minutes. When growing
-      persistent disk size above 4TB, this maximum wait time may need to be
-      increased. The value here is a factor of the base ≈25 minutes wait
-      time. For example a factor of 3 would lead to a wait time of ≈75
-      minutes.
-    default: 4
   aws.metadata_options:
     description: |
       Metadata configuration options that are set on a VM during creation. These options should be snake-cased

--- a/jobs/aws_cpi/templates/cpi.json.erb
+++ b/jobs/aws_cpi/templates/cpi.json.erb
@@ -13,7 +13,6 @@ params = {
         "default_key_name" => p('aws.default_key_name'),
         "default_security_groups" => p('aws.default_security_groups'),
         "max_retries" => p('aws.max_retries'),
-        "extend_ebs_volume_wait_time_factor" => p('aws.extend_ebs_volume.wait_time_factor'),
         "encrypted" => p('aws.encrypted'),
         "kms_key_arn" => p('aws.kms_key_arn', nil),
         "metadata_options" => p('aws.metadata_options', nil)

--- a/src/bosh_aws_cpi/lib/cloud/aws/cloud_v1.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/cloud_v1.rb
@@ -42,7 +42,7 @@ module Bosh::AwsCloud
       @ec2_client = @aws_provider.ec2_client
       @ec2_resource = @aws_provider.ec2_resource
       @az_selector = AvailabilityZoneSelector.new(@ec2_resource)
-      @volume_manager = Bosh::AwsCloud::VolumeManager.new(@config.aws, @logger, @aws_provider)
+      @volume_manager = Bosh::AwsCloud::VolumeManager.new(@logger, @aws_provider)
 
       @cloud_core = CloudCore.new(@config, @logger, @volume_manager, @az_selector, API_VERSION)
 

--- a/src/bosh_aws_cpi/lib/cloud/aws/config.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/config.rb
@@ -1,6 +1,6 @@
 module Bosh::AwsCloud
   class AwsConfig
-    attr_reader :max_retries, :extend_ebs_volume_wait_time_factor, :credentials
+    attr_reader :max_retries, :credentials
     attr_reader :region, :ec2_endpoint, :elb_endpoint, :stemcell
     attr_reader :access_key_id, :secret_access_key, :default_key_name, :encrypted, :kms_key_arn
     attr_reader :default_iam_instance_profile, :default_security_groups, :metadata_options
@@ -12,7 +12,6 @@ module Bosh::AwsCloud
       @config = aws_config_hash
 
       @max_retries = @config['max_retries']
-      @extend_ebs_volume_wait_time_factor = @config['extend_ebs_volume_wait_time_factor']
 
       @region = @config['region']
       @ec2_endpoint = @config['ec2_endpoint']

--- a/src/bosh_aws_cpi/lib/cloud/aws/resource_wait.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/resource_wait.rb
@@ -78,13 +78,11 @@ module Bosh::AwsCloud
       valid_states = ['modifying', 'optimizing', 'completed', 'failed']
       target_states.each { |target_state| validate_states(valid_states, target_state) }
       target_state_desc = target_states.join(' or ')
-      wait_time_factor = args.fetch(:wait_time_factor, 1).to_i
 
       description = "volume modification of %s current state %s" % [volume_modification.volume.id, volume_modification.state]
-      max_tries = DEFAULT_TRIES * wait_time_factor
 
       new.for_resource(resource: volume_modification, target_state_desc: target_state_desc,
-                       description: description, tries: max_tries) do |current_state|
+                       description: description) do |current_state|
         target_states.include?(current_state)
       end
 

--- a/src/bosh_aws_cpi/lib/cloud/aws/resource_wait.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/resource_wait.rb
@@ -79,15 +79,10 @@ module Bosh::AwsCloud
       validate_states(valid_states, target_state)
       wait_time_factor = args.fetch(:wait_time_factor, 1).to_i
 
-      ignored_errors = []
-      if target_state == 'completed'
-        ignored_errors << Aws::EC2::Errors::InvalidVolumeNotFound
-        ignored_errors << Aws::EC2::Errors::ResourceNotFound
-      end
       description = "volume modification of %s current state %s" % [volume_modification.volume.id, volume_modification.state]
       max_tries = DEFAULT_TRIES * wait_time_factor
 
-      new.for_resource(resource: volume_modification, errors: ignored_errors,
+      new.for_resource(resource: volume_modification,
                        target_state_desc: target_state, description: description, tries: max_tries) do |current_state|
         current_state == target_state
       end

--- a/src/bosh_aws_cpi/lib/cloud/aws/sdk_helpers/volume_manager.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/sdk_helpers/volume_manager.rb
@@ -26,7 +26,7 @@ module Bosh::AwsCloud
 
       args = {
         volume_modification: volume_modification,
-        state: 'completed'
+        states: [ 'optimizing', 'completed' ]
       }
       unless @aws_config.extend_ebs_volume_wait_time_factor.nil?
         args[:wait_time_factor] = @aws_config.extend_ebs_volume_wait_time_factor

--- a/src/bosh_aws_cpi/lib/cloud/aws/sdk_helpers/volume_manager.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/sdk_helpers/volume_manager.rb
@@ -1,8 +1,7 @@
 module Bosh::AwsCloud
   class VolumeManager
 
-    def initialize(aws_config, logger, aws_provider)
-      @aws_config = aws_config
+    def initialize(logger, aws_provider)
       @logger = logger
       @ec2_resource = aws_provider.ec2_resource
       @ec2_client = aws_provider.ec2_client
@@ -24,14 +23,8 @@ module Bosh::AwsCloud
       volume_modification = SdkHelpers::VolumeModification.new(volume, resp.volume_modification, @ec2_client)
       @logger.info("Extending volume `#{volume.id}'")
 
-      args = {
-        volume_modification: volume_modification,
-        states: [ 'optimizing', 'completed' ]
-      }
-      unless @aws_config.extend_ebs_volume_wait_time_factor.nil?
-        args[:wait_time_factor] = @aws_config.extend_ebs_volume_wait_time_factor
-      end
-      ResourceWait.for_volume_modification(args)
+      ResourceWait.for_volume_modification(volume_modification: volume_modification,
+                                           states: [ 'optimizing', 'completed' ])
     end
 
     def delete_ebs_volume(volume, fast_path_delete = false)

--- a/src/bosh_aws_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -59,7 +59,6 @@ describe 'cpi.json.erb' do
             'default_security_groups'=>['security_group_1'],
             'region' => 'moon',
             'max_retries' => 8,
-            'extend_ebs_volume_wait_time_factor' => 4,
             'encrypted' => false,
             'kms_key_arn' => nil,
             'metadata_options' => nil
@@ -190,17 +189,6 @@ describe 'cpi.json.erb' do
     it 'uses the value set' do
       manifest['properties']['aws']['default_iam_instance_profile'] = 'some_default_instance_profile'
       expect(subject['cloud']['properties']['aws']['default_iam_instance_profile']).to eq('some_default_instance_profile')
-    end
-  end
-
-  context 'given a customized extend_ebs_volume_wait_time_factor' do
-    before do
-      manifest['properties']['aws']['extend_ebs_volume'] ||= {}
-      manifest['properties']['aws']['extend_ebs_volume']['wait_time_factor'] = 77
-    end
-
-    it 'uses the value set' do
-      expect(subject['cloud']['properties']['aws']['extend_ebs_volume_wait_time_factor']).to eq(77)
     end
   end
 

--- a/src/bosh_aws_cpi/spec/unit/resize_disk_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/resize_disk_spec.rb
@@ -17,7 +17,7 @@ describe Bosh::AwsCloud::CloudV1, "resize_disk" do
     modification = instance_double(Bosh::AwsCloud::SdkHelpers::VolumeModification, :state => 'completed')
     allow(Bosh::AwsCloud::SdkHelpers::VolumeModification).to receive(:new).with(volume, volume_resp.volume_modification, @ec2.client).and_return(modification)
     allow(Bosh::AwsCloud::ResourceWait).to receive(:for_volume_modification)
-      .with(volume_modification: modification, state: 'completed')
+      .with(volume_modification: modification, states: [ 'optimizing', 'completed' ])
   end
 
 

--- a/src/bosh_aws_cpi/spec/unit/resource_wait_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/resource_wait_spec.rb
@@ -195,7 +195,7 @@ module Bosh::AwsCloud
           resource: resource,
           tries: 1,
           description: 'description',
-          target_state: 'foo'
+          target_state_desc: 'foo'
         }
 
         expect {
@@ -235,7 +235,7 @@ module Bosh::AwsCloud
         {
           resource: fake_resource,
           description: 'description',
-          target_state: 'fake-target-state',
+          target_state_desc: 'fake-target-state',
         }
       end
 

--- a/src/bosh_aws_cpi/spec/unit/resource_wait_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/resource_wait_spec.rb
@@ -100,11 +100,11 @@ module Bosh::AwsCloud
         it 'should wait until the state is completed' do
           expect(volume_modification).to receive(:state).and_return('modifying')
           expect(volume_modification).to receive(:state).and_return('optimizing')
-          expect(volume_modification).to receive(:state).and_return('completed')
+          allow(volume_modification).to receive(:state).and_return('completed')
 
           described_class.for_volume_modification(
             volume_modification: volume_modification,
-            state: 'completed')
+            states: [ 'optimizing', 'completed' ])
         end
 
         it 'should raise an error on failed state' do
@@ -114,8 +114,8 @@ module Bosh::AwsCloud
           expect {
             described_class.for_volume_modification(
               volume_modification: volume_modification,
-              state: 'completed')
-          }.to raise_error Bosh::Clouds::CloudError, /state is failed, expected completed/
+              states: [ 'optimizing', 'completed' ])
+          }.to raise_error Bosh::Clouds::CloudError, /state is failed, expected optimizing or completed/
         end
       end
     end


### PR DESCRIPTION
Hi there,

In #122, we've seen that when resizing disks, the `optimizing` state is only a backend concern on the AWS EBS servers infrastructure, for delivering the promised performance. So for a Bosh CPI concern, there is no need to wait for the EBS backend reorganisation to finish with the `completed` state. This is good news as our production clusters were taking days for the optimisations to finish.

Here in this PR, we provide an implementation for the CPI to move on once the [VolumeModification](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_VolumeModification.html) reaches the `optimizing` or `completed` states.

With this new approach, the `aws.extend_ebs_volume.wait_time_factor` config property introduced in #119 is no more necessary, so it has been removed. Which is also good news because its concept was a bit sloppy, as mentioned during review.

Unit tests are passing and we've tested successfully this code for resizing some development cluster. It' now lightning fast!

We need quick reviews on this code, in order to resize big data clusters in the upcoming days.
Thank you!