### PR TITLE
Gp3 throughput and IOPS support

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -35,7 +35,7 @@ With bundler installed, run the vendoring script from `src/bosh_aws_cpi`:
 Then create the BOSH release from the root directory:
 
 ```
-bosh create release --force
+bosh create-release --force
 ```
 
 The release is now ready for use. If everything works, commit the changes including the updated gems.

--- a/src/bosh_aws_cpi/lib/cloud/aws/block_device_manager.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/block_device_manager.rb
@@ -140,6 +140,7 @@ module Bosh::AwsCloud
           size: disk_size,
           type: ephemeral_disk.type,
           iops: ephemeral_disk.iops,
+          throughput: ephemeral_disk.throughput,
           encrypted: ephemeral_disk.encrypted,
           kms_key_arn: ephemeral_disk.kms_key_arn,
         ).ephemeral_disk_config
@@ -185,6 +186,7 @@ module Bosh::AwsCloud
         size: @vm_cloud_props.root_disk.size,
         type: @vm_cloud_props.root_disk.type,
         iops: @vm_cloud_props.root_disk.iops,
+        throughput: @vm_cloud_props.root_disk.throughput,
         virtualization_type: @virtualization_type,
         root_device_name: root_device_name,
       )

--- a/src/bosh_aws_cpi/lib/cloud/aws/cloud_props.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/cloud_props.rb
@@ -63,14 +63,14 @@ module Bosh::AwsCloud
   end
 
   class DiskCloudProps
-    attr_reader :type, :iops, :encrypted, :kms_key_arn
+    attr_reader :type, :iops, :throughput, :encrypted, :kms_key_arn
 
     # @param [Hash] cloud_properties
     # @param [Bosh::AwsCloud::Config] global_config
     def initialize(cloud_properties, global_config)
       @type = cloud_properties['type']
       @iops = cloud_properties['iops']
-
+      @throughput = cloud_properties['throughput']
       @encrypted = global_config.aws.encrypted
       @encrypted = !!cloud_properties['encrypted'] if cloud_properties.key?('encrypted')
 
@@ -158,7 +158,7 @@ module Bosh::AwsCloud
     end
 
     class Disk
-      attr_reader :size, :type, :iops, :disk
+      attr_reader :size, :type, :iops, :throughput, :disk
 
       def initialize(disk)
         if disk
@@ -167,6 +167,7 @@ module Bosh::AwsCloud
           @size = disk['size']
           @type = disk['type']
           @iops = disk['iops']
+          @throughput = disk['throughput']
         end
       end
 

--- a/src/bosh_aws_cpi/lib/cloud/aws/cloud_v1.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/cloud_v1.rb
@@ -208,6 +208,7 @@ module Bosh::AwsCloud
           size: size,
           type: props.type,
           iops: props.iops,
+          throughput: props.throughput,
           az: @az_selector.select_availability_zone(instance_id),
           encrypted: props.encrypted,
           kms_key_arn: props.kms_key_arn

--- a/src/bosh_aws_cpi/lib/cloud/aws/volume_properties.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/volume_properties.rb
@@ -60,15 +60,11 @@ module Bosh
           root_device[:volume_size] = size_in_gb
         end
 
-        if @type == 'io1' && @iops > 0
-          root_device[:iops] = @iops
-        end
-        #On GP3 you can leave those values empty and get 3000 iops/125mb/s throughput
-        if @type == 'gp3' && @iops != nil && @iops > 0
+        if %w(io1 gp3).include?(@type) && @iops.to_i.positive?
           root_device[:iops] = @iops
         end
 
-        if @type == 'gp3' && @throughput != nil && @throughput > 0
+        if @type == 'gp3' && @throughput.to_i.positive?
           root_device[:throughput] = @throughput
         end
 

--- a/src/bosh_aws_cpi/lib/cloud/aws/volume_properties.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/volume_properties.rb
@@ -3,12 +3,13 @@ module Bosh
     class VolumeProperties
       include Helpers
 
-      attr_reader :size, :az, :iops, :type, :encrypted
+      attr_reader :size, :az, :iops, :throughput, :type, :encrypted
 
       def initialize(options)
         @size = options[:size] || 0
         @type = options[:type] || 'gp3'
         @iops = options[:iops]
+        @throughput = options[:throughput]
         @az = options[:az]
         @kms_key_arn = options[:kms_key_arn]
         @encrypted = options[:encrypted] || false
@@ -24,6 +25,7 @@ module Bosh
         }
 
         mapping[:iops] = @iops if @iops
+        mapping[:throughput] = @throughput if @throughput
         mapping[:encrypted] = @encrypted if @encrypted
         mapping[:kms_key_id] = @kms_key_arn if @kms_key_arn
 
@@ -39,6 +41,7 @@ module Bosh
         }
 
         output[:iops] = @iops if @iops
+        output[:throughput] = @throughput if @throughput
         output[:kms_key_id] = @kms_key_arn if @kms_key_arn
         unless @tags.empty?
           output[:tag_specifications] = [
@@ -59,6 +62,14 @@ module Bosh
 
         if @type == 'io1' && @iops > 0
           root_device[:iops] = @iops
+        end
+        #On GP3 you can leave those values empty and get 3000 iops/125mb/s throughput
+        if @type == 'gp3' && @iops != nil && @iops > 0
+          root_device[:iops] = @iops
+        end
+
+        if @type == 'gp3' && @throughput != nil && @throughput > 0
+          root_device[:throughput] = @throughput
         end
 
         {


### PR DESCRIPTION
Adding support for both iops and throughput values of GP3 disks. 

- Added tests that test iops and throughput in the same fashion as io1s iops are tested
- Works on root, ephemeral and persistent disks.
- Note: values below the base of 3000 iops and 125mbps that are specified will be bumped by amazon to the baseline. 
- Test suite for block_device_manager are green. Due to me not having a playground AWS account I have not ran the full suite (as I did not touch most of the CPI)
- Manual integration test on AWS done. 