### PR TITLE
Add rexml as top level dependency

### DIFF
--- a/src/bosh_aws_cpi/Gemfile
+++ b/src/bosh_aws_cpi/Gemfile
@@ -5,6 +5,7 @@ gem 'aws-sdk-autoscaling',            '~> 1.59'
 gem 'aws-sdk-elasticloadbalancing',   '~> 1.31'
 gem 'aws-sdk-elasticloadbalancingv2', '~> 1.61'
 
+gem 'rexml',                          '~> 3.2.5'
 gem 'bosh_common', '1.3262.24.0'
 gem 'bosh_cpi'
 

--- a/src/bosh_aws_cpi/Gemfile.lock
+++ b/src/bosh_aws_cpi/Gemfile.lock
@@ -89,6 +89,7 @@ DEPENDENCIES
   bosh_cpi
   pry-byebug (~> 3.4)
   rake (~> 12.3)
+  rexml (~> 3.2.5)
   rspec (~> 3.5)
   webmock
 


### PR DESCRIPTION
During my tests for the GP3 throughput and iops PR #126 I had the issue that the CPI would emit errors on compile: 

`set_default_engine': Unable to find a compatible xml library. Ensure that you have installed or added to your Gemfile one of ox, oga, libxml, nokogiri or rexml (RuntimeError)

I checked the Gemfile and Gemfile.lock and saw rexml was not being vendored, as the only Gem requiring it was crack, which in turn was required by webmock. This caused no xml runtime to be present.

Why this worked in the past or currently on release building, I do not know, but adding the Gem to the Gemfile made it so dev releases were able to compile and run on a BOSH director.