### PR TITLE
Refactor/remove old stemcell usage

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -68,7 +68,9 @@ jobs:
   - in_parallel:
     - {trigger: true,  passed: [build-candidate], get: bosh-cpi-release, resource: bosh-cpi-dev-artifacts}
     - {trigger: false, passed: [build-candidate], get: bosh-cpi-src, resource: bosh-cpi-src-in}
+    - {get: stemcell,        trigger: true, resource: light-stemcell}
     - {get: aws-cpi-image }
+
   - put: environment
     params:
       env_name: bosh-aws-cpi-integration
@@ -324,7 +326,7 @@ resources:
 - name: light-stemcell
   type: bosh-io-stemcell
   source:
-    name: bosh-aws-xen-hvm-ubuntu-xenial-go_agent
+    name: bosh-aws-xen-hvm-ubuntu-jammy-go_agent
 - name: aws-cpi-image
   type: docker-image
   source:

--- a/ci/tasks/run-integration.sh
+++ b/ci/tasks/run-integration.sh
@@ -8,6 +8,9 @@ set -e
 : ${BOSH_AWS_KMS_KEY_ARN:?}
 : ${BOSH_AWS_KMS_KEY_ARN_OVERRIDE:?}
 
+tar -xzf stemcell/light-*.tgz stemcell.MF
+export BOSH_AWS_IMAGE_ID=$(cat stemcell.MF | grep $AWS_DEFAULT_REGION | tr -d ' ' | cut -f2 -d:)
+
 # NOTE: To run with specific line numbers, set:
 # RSPEC_ARGUMENTS="spec/integration/lifecycle_spec.rb:mm:nn"
 : ${RSPEC_ARGUMENTS:=spec/integration}

--- a/ci/tasks/run-integration.yml
+++ b/ci/tasks/run-integration.yml
@@ -6,6 +6,7 @@ image_resource:
 inputs:
   - name: bosh-cpi-src
   - name: environment
+  - name: stemcell
 run:
   path: bosh-cpi-src/ci/tasks/run-integration.sh
 params:

--- a/src/bosh_aws_cpi/spec/integration/lifecycle_spec.rb
+++ b/src/bosh_aws_cpi/spec/integration/lifecycle_spec.rb
@@ -17,7 +17,7 @@ describe 'lifecycle test' do
   let(:instance_type_ipv6)                { 't2.small' } # "IPv6 is not supported for the instance type 'm3.medium'"
   let(:ami)                               { hvm_ami }
   let(:hvm_ami)                           { ENV.fetch('BOSH_AWS_IMAGE_ID', 'ami-9c91b7fc') }
-  let(:pv_ami)                            { ENV.fetch('BOSH_AWS_PV_IMAGE_ID', 'ami-3f71225f') }
+# let(:pv_ami)                            { ENV.fetch('BOSH_AWS_PV_IMAGE_ID', 'ami-3f71225f') }
   let(:windows_ami)                       { ENV.fetch('BOSH_AWS_WINDOWS_IMAGE_ID', 'ami-9be0a8fb') }
   let(:eip)                               { ENV.fetch('BOSH_AWS_ELASTIC_IP') }
   let(:instance_type) { instance_type_with_ephemeral }

--- a/src/bosh_aws_cpi/spec/integration/manual_network_spec.rb
+++ b/src/bosh_aws_cpi/spec/integration/manual_network_spec.rb
@@ -21,7 +21,7 @@ describe Bosh::AwsCloud::CloudV1 do
   let(:instance_type_ipv6)                { 't2.small' } # "IPv6 is not supported for the instance type 'm3.medium'"
   let(:ami)                               { hvm_ami }
   let(:hvm_ami)                           { ENV.fetch('BOSH_AWS_IMAGE_ID', 'ami-9c91b7fc') }
-  let(:pv_ami)                            { ENV.fetch('BOSH_AWS_PV_IMAGE_ID', 'ami-3f71225f') }
+# let(:pv_ami)                            { ENV.fetch('BOSH_AWS_PV_IMAGE_ID', 'ami-3f71225f') }
   let(:windows_ami)                       { ENV.fetch('BOSH_AWS_WINDOWS_IMAGE_ID', 'ami-f8dfd698') }
   let(:eip)                               { ENV.fetch('BOSH_AWS_ELASTIC_IP') }
   let(:ipv6_ip)                           { ENV.fetch('BOSH_AWS_MANUAL_IPV6_IP') }
@@ -795,15 +795,15 @@ describe Bosh::AwsCloud::CloudV1 do
             end
           end
 
-          context 'and AMI is paravirtual' do
-            let(:root_disk_vm_props) do
-              { ami_id: pv_ami }
-            end
+#         context 'and AMI is paravirtual' do
+#           let(:root_disk_vm_props) do
+#             { ami_id: pv_ami }
+#           end
 
-            it 'requests root disk with the default type and size' do
-              verify_root_disk_properties
-            end
-          end
+#           it 'requests root disk with the default type and size' do
+#             verify_root_disk_properties
+#           end
+#         end
 
           context 'and AMI is Windows' do
             let(:root_disk_vm_props) do
@@ -838,15 +838,15 @@ describe Bosh::AwsCloud::CloudV1 do
             end
           end
 
-          context 'and AMI is pv' do
-            let(:root_disk_vm_props) do
-              { ami_id: pv_ami }
-            end
+#         context 'and AMI is pv' do
+#           let(:root_disk_vm_props) do
+#             { ami_id: pv_ami }
+#           end
 
-            it 'requests root disk with the specified size and type gp3' do
-              verify_root_disk_properties
-            end
-          end
+#           it 'requests root disk with the specified size and type gp3' do
+#             verify_root_disk_properties
+#           end
+#         end
 
           context 'and AMI is Windows' do
             let(:root_disk_vm_props) do
@@ -881,15 +881,15 @@ describe Bosh::AwsCloud::CloudV1 do
               end
             end
 
-            context 'and AMI is pv' do
-              let(:root_disk_vm_props) do
-                { ami_id: pv_ami }
-              end
+#           context 'and AMI is pv' do
+#             let(:root_disk_vm_props) do
+#               { ami_id: pv_ami }
+#             end
 
-              it 'requests root disk with the specified size and type gp3' do
-                verify_root_disk_properties
-              end
-            end
+#             it 'requests root disk with the specified size and type gp3' do
+#               verify_root_disk_properties
+#             end
+#           end
 
             context 'and AMI is Windows' do
               let(:root_disk_vm_props) do


### PR DESCRIPTION
We are currently using either old xenial stemcells from bosh io (basically pinned to 621.125 which was the last one published before xenial went ESM)
or very old hardcoded light amis for running integration tests since the env var for specifying the AMI wasn't set in the integration script.
finally we're still running tests for paravirtual stemcells that we do not publish anymore since these were fully replaced by hvm stemcells. we can save some runtime and get a faster feedback by skipping these tests.
