### PR TITLE
Add assume role support in the AWS CPI

### DIFF
--- a/ci/assets/terraform/template.tf
+++ b/ci/assets/terraform/template.tf
@@ -1,5 +1,6 @@
 variable "access_key" {}
 variable "secret_key" {}
+variable "role_arn" {}
 variable "session_token" {
   default = ""
 }
@@ -12,6 +13,9 @@ provider "aws" {
   secret_key = var.secret_key
   token = var.session_token
   region = var.region
+  assume_role {
+    role_arn = var.role_arn
+  }
 }
 
 data "aws_availability_zones" "available" {}

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -7,8 +7,9 @@ shared:
   params: &prepare-director-params
     INFRASTRUCTURE:     aws
     DIRECTOR_VARS_FILE: |
-      access_key_id: ((aws-cpi-integration-tests_aws_access_key.username))
-      secret_access_key: ((aws-cpi-integration-tests_aws_access_key.password))
+      access_key_id: ((aws-cpi-integration-tests_assume_aws_access_key.username))
+      secret_access_key: ((aws-cpi-integration-tests_assume_aws_access_key.password))
+      role_arn: ((aws-cpi-integration-tests_assume_aws_access_key.role_arn))
       region: us-west-1
 
 - &deploy-director
@@ -84,10 +85,12 @@ jobs:
     file: bosh-cpi-src/ci/tasks/run-integration.yml
     image: aws-cpi-image
     params:
-      AWS_ACCESS_KEY_ID:                       ((aws-cpi-integration-tests_aws_access_key.username))
-      AWS_SECRET_ACCESS_KEY:                   ((aws-cpi-integration-tests_aws_access_key.password))
-      BOSH_AWS_PERMISSIONS_AUDITOR_KEY_ID:     ((iam-permission-auditor_aws_access_key.username))
-      BOSH_AWS_PERMISSIONS_AUDITOR_SECRET_KEY: ((iam-permission-auditor_aws_access_key.password))
+      AWS_ACCESS_KEY_ID:                       ((aws-cpi-integration-tests_assume_aws_access_key.username))
+      AWS_SECRET_ACCESS_KEY:                   ((aws-cpi-integration-tests_assume_aws_access_key.password))
+      AWS_ROLE_ARN:                            ((aws-cpi-integration-tests_assume_aws_access_key.role_arn))
+      BOSH_AWS_PERMISSIONS_AUDITOR_KEY_ID:     ((iam-permission-auditor_assume_aws_access_key.username))
+      BOSH_AWS_PERMISSIONS_AUDITOR_SECRET_KEY: ((iam-permission-auditor_assume_aws_access_key.password))
+      BOSH_AWS_PERMISSIONS_AUDITOR_ROLE_ARN:   ((iam-permission-auditor_assume_aws_access_key.role_arn))
       AWS_DEFAULT_REGION:                      us-west-1
       BOSH_AWS_KMS_KEY_ARN:                    ((arn_keys.aws_kms_key_arn))
       BOSH_AWS_KMS_KEY_ARN_OVERRIDE:           ((arn_keys.aws_kms_key_arn_override))
@@ -131,6 +134,7 @@ jobs:
           -o pipelines/shared/assets/ops/remove-hm.yml
           -o bosh-deployment/external-ip-with-registry-not-recommended.yml
           -o pipelines/shared/assets/ops/remove-provider-cert.yml
+          -o bosh-deployment/aws/cpi-assume-role-credentials.yml
     - do:
         - <<: *deploy-director
         - <<: *run-bats
@@ -177,6 +181,7 @@ jobs:
           -o bosh-deployment/external-ip-with-registry-not-recommended.yml
           -o pipelines/shared/assets/ops/remove-provider-cert.yml
           -o pipelines/aws/assets/ops/iam-instance-profile-ops-file.yml
+          -o bosh-deployment/aws/cpi-assume-role-credentials.yml
     - do:
         - <<: *deploy-director
         - <<: *run-end-2-end
@@ -293,8 +298,9 @@ resources:
       bucket:            bosh-aws-cpi-terraform
       bucket_path:       terraform-state
     vars:
-      access_key: ((bosh_cpis_aws_access_key.username))
-      secret_key: ((bosh_cpis_aws_access_key.password))
+      access_key: ((bosh_cpis_assume_aws_access_key.username))
+      secret_key: ((bosh_cpis_assume_aws_access_key.password))
+      role_arn:   ((bosh_cpis_assume_aws_access_key.role_arn))
       region:     us-west-1
       public_key: ((integration_vm_keypair.public_key))
 - name: bosh-cli

--- a/ci/tasks/run-integration.sh
+++ b/ci/tasks/run-integration.sh
@@ -27,6 +27,9 @@ export BOSH_AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
 if [ "${AWS_SESSION_TOKEN}" ]; then
 	export BOSH_AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
 fi
+if [ "${AWS_ROLE_ARN}" ]; then
+	export BOSH_AWS_ROLE_ARN=${AWS_ROLE_ARN}
+fi
 export BOSH_AWS_DEFAULT_KEY_NAME=$(echo ${metadata} | jq -e --raw-output ".default_key_name")
 export BOSH_AWS_REGION=$(echo ${metadata} | jq -e --raw-output ".region")
 export BOSH_AWS_SUBNET_ID=$(echo ${metadata} | jq -e --raw-output ".subnet_id")

--- a/ci/tasks/run-integration.yml
+++ b/ci/tasks/run-integration.yml
@@ -12,10 +12,12 @@ run:
 params:
   AWS_ACCESS_KEY_ID:                       ""
   AWS_SECRET_ACCESS_KEY:                   ""
+  AWS_ROLE_ARN:                            ""
   AWS_DEFAULT_REGION:                      ""
   BOSH_AWS_KMS_KEY_ARN:                    ""
   BOSH_AWS_KMS_KEY_ARN_OVERRIDE:           ""
   BOSH_AWS_PERMISSIONS_AUDITOR_KEY_ID:     ""
   BOSH_AWS_PERMISSIONS_AUDITOR_SECRET_KEY: ""
+  BOSH_AWS_PERMISSIONS_AUDITOR_ROLE_ARN:   ""
   BOSH_AWS_CPI_API_VERSION:
   BOSH_AWS_WINDOWS_IMAGE_ID:

--- a/jobs/aws_cpi/spec
+++ b/jobs/aws_cpi/spec
@@ -26,6 +26,9 @@ properties:
   aws.session_token:
     description: AWS session_token when using STS credentials for the aws cpi (Optional, used when aws.credentials_source is set to `static`)
     default: null
+  aws.role_arn:
+    description: AWS role_arn to be assumed by the CPI when authenticating (Optional, used when aws.credentials_source is set to `static`)
+    default: null
   aws.default_iam_instance_profile:
     description: Default AWS iam_instance_profile for the aws cpi
     default: null

--- a/jobs/aws_cpi/templates/cpi.json.erb
+++ b/jobs/aws_cpi/templates/cpi.json.erb
@@ -9,6 +9,7 @@ params = {
         "access_key_id" => p('aws.access_key_id', nil),
         "secret_access_key" => p('aws.secret_access_key', nil),
         "session_token" => p('aws.session_token', nil),
+        "role_arn" => p('aws.role_arn', nil),
         "default_iam_instance_profile" => p('aws.default_iam_instance_profile', nil),
         "default_key_name" => p('aws.default_key_name', nil),
         "default_security_groups" => p('aws.default_security_groups'),

--- a/src/bosh_aws_cpi/bin/test-integration
+++ b/src/bosh_aws_cpi/bin/test-integration
@@ -4,6 +4,7 @@ set -e
 
 : ${AWS_ACCESS_KEY_ID:?}
 : ${AWS_SECRET_ACCESS_KEY:?}
+: ${AWS_ROLE_ARN:?}
 : ${AWS_DEFAULT_REGION:=us-west-1}
 : ${PROJECT_RUBY_VERSION:?}
 : ${BOSH_AWS_KMS_KEY_ARN:?}
@@ -15,6 +16,7 @@ function destroy_env() {
     terraform destroy -force -state="${STATE_FILE}" \
       -var "access_key=${AWS_ACCESS_KEY_ID}" \
       -var "secret_key=${AWS_SECRET_ACCESS_KEY}" \
+      -var "role_arn=${AWS_ROLE_ARN}" \
       ${AWS_SESSION_TOKEN:+-var "session_token=${AWS_SESSION_TOKEN}"} \
       -var "region=${AWS_DEFAULT_REGION}" \
       -var "env_name=$(hostname -s|tr '[:upper:]' '[:lower:]')-local-int" \
@@ -29,6 +31,7 @@ function create_env() {
       -auto-approve \
       -var "access_key=${AWS_ACCESS_KEY_ID}" \
       -var "secret_key=${AWS_SECRET_ACCESS_KEY}" \
+      -var "role_arn=${AWS_ROLE_ARN}" \
       ${AWS_SESSION_TOKEN:+-var "session_token=${AWS_SESSION_TOKEN}"} \
       -var "region=${AWS_DEFAULT_REGION}" \
       -var "env_name=$(hostname -s|tr '[:upper:]' '[:lower:]')-local-int" \

--- a/src/bosh_aws_cpi/lib/cloud/aws/config.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/config.rb
@@ -9,6 +9,7 @@ module Bosh::AwsCloud
     CREDENTIALS_SOURCE_ENV_OR_PROFILE = 'env_or_profile'.freeze
 
     def initialize(aws_config_hash)
+      @logger = Bosh::Clouds::Config.logger
       @config = aws_config_hash
 
       @max_retries = @config['max_retries']
@@ -19,6 +20,7 @@ module Bosh::AwsCloud
 
       @access_key_id = @config['access_key_id']
       @secret_access_key = @config['secret_access_key']
+      @role_arn = @config['role_arn']
       @session_token = @config['session_token']
       @default_iam_instance_profile = @config['default_iam_instance_profile']
       @default_key_name = @config['default_key_name']
@@ -36,10 +38,32 @@ module Bosh::AwsCloud
       @credentials_source = @config['credentials_source'] || CREDENTIALS_SOURCE_STATIC
       @credentials =
         if @credentials_source == CREDENTIALS_SOURCE_STATIC
-          Aws::Credentials.new(@access_key_id, @secret_access_key, @session_token)
+          static_credentials
         else
+          @logger.info("Using InstanceProfileCredentials.")
           Aws::InstanceProfileCredentials.new(retries: 10)
         end
+    end
+
+    def static_credentials
+      if @role_arn.nil? || @role_arn.empty?
+        @logger.info("Using static Credentials")
+        Aws::Credentials.new(@access_key_id, @secret_access_key, @session_token)
+      else
+        @logger.info("Using AssumeRoleCredentials. Role: #{@role_arn}")
+
+        sts_client = Aws::STS::Client.new(
+          region: @region,
+          access_key_id: @access_key_id,
+          secret_access_key: @secret_access_key,
+          session_token: @session_token
+        )
+        Aws::AssumeRoleCredentials.new(
+          client: sts_client,
+          role_arn: @role_arn,
+          role_session_name: 'rsn' + '-' + SecureRandom.uuid
+        )
+      end
     end
 
     def to_h

--- a/src/bosh_aws_cpi/spec/integration/manual_network_spec.rb
+++ b/src/bosh_aws_cpi/spec/integration/manual_network_spec.rb
@@ -679,6 +679,7 @@ describe Bosh::AwsCloud::CloudV1 do
               'fast_path_delete' => 'yes',
               'access_key_id' => @access_key_id,
               'secret_access_key' => @secret_access_key,
+              'session_token' => @session_token,
               'max_retries' => 8,
               'encrypted' => true,
               'kms_key_arn' => @kms_key_arn

--- a/src/bosh_aws_cpi/spec/integration/spec_helper.rb
+++ b/src/bosh_aws_cpi/spec/integration/spec_helper.rb
@@ -3,6 +3,7 @@ require 'integration/helpers/ec2_helper'
 require 'aws-sdk-iam'
 
 MOCK_CPI_API_VERSION = 2
+
 def validate_minimum_permissions(logger)
   if @permissions_auditor_key_id && @permissions_auditor_secret_key
     sts_client = Aws::STS::Client.new(
@@ -11,26 +12,29 @@ def validate_minimum_permissions(logger)
       secret_access_key: @secret_access_key,
       session_token: @session_token
     )
-    integration_test_user_arn = sts_client.get_caller_identity.arn
-    raise 'Cannot get user ARN' if integration_test_user_arn.nil?
+    integration_test_user = sts_client.get_caller_identity
+    raise 'Cannot get user ARN' if integration_test_user.arn.nil?
 
     iam_client = Aws::IAM::Client.new(
       region: @region,
       access_key_id: @permissions_auditor_key_id,
       secret_access_key: @permissions_auditor_secret_key,
-      session_token: @session_token,
+      session_token: @permissions_auditor_session_token,
       logger: logger
     )
 
-    user_details = iam_client.get_account_authorization_details(filter: ['User']).user_detail_list.find { |user| user.arn == integration_test_user_arn }
-    raise "Cannot find user with ARN: #{integration_test_user_arn}" if user_details.nil?
+    account_details = iam_client.get_account_authorization_details(filter: ['Role']).role_detail_list.find { |role|
+      role.arn == 'arn:aws:iam::' + integration_test_user.account + ':role/' + integration_test_user.arn.split('/')[1]
+    }
+
+    raise "Cannot find role with ARN: #{integration_test_user.arn}" if account_details.nil?
 
     policy_documents = []
-    policy_documents += user_details.attached_managed_policies.map do |p|
+    policy_documents += account_details.attached_managed_policies.map do |p|
       version_id = iam_client.get_policy(policy_arn: p.policy_arn).policy.default_version_id
       iam_client.get_policy_version(policy_arn: p.policy_arn, version_id: version_id).policy_version.document
     end
-    policy_documents += user_details.user_policy_list.map(&:policy_document)
+    policy_documents += account_details.role_policy_list.map(&:policy_document)
 
     actions = policy_documents.map do |document|
       JSON.parse(URI.decode_www_form_component(document))['Statement'].map do |s|
@@ -42,28 +46,62 @@ def validate_minimum_permissions(logger)
       s['Action']
     end.flatten.uniq
 
-    expect(actions).to match_array(minimum_action)
+    expect(actions).to include(*minimum_action)
   end
+end
+
+def set_assume_role_permissions
+  if ENV.fetch('BOSH_AWS_PERMISSIONS_AUDITOR_KEY_ID', nil) && ENV.fetch('BOSH_AWS_PERMISSIONS_AUDITOR_SECRET_KEY', nil)
+    auditor_sts_client = Aws::STS::Client.new(
+      region: ENV.fetch('BOSH_AWS_REGION', 'us-west-1'),
+      access_key_id: ENV.fetch('BOSH_AWS_PERMISSIONS_AUDITOR_KEY_ID'),
+      secret_access_key: ENV.fetch('BOSH_AWS_PERMISSIONS_AUDITOR_SECRET_KEY'),
+      session_token: nil
+    )
+    auditor_assumed_credentials = auditor_sts_client.assume_role(
+      {
+        role_arn: ENV.fetch('BOSH_AWS_PERMISSIONS_AUDITOR_ROLE_ARN', nil),
+        role_session_name: 'rsn' + '-' + SecureRandom.uuid
+      }
+    ).credentials
+
+    @permissions_auditor_key_id = auditor_assumed_credentials.access_key_id
+    @permissions_auditor_secret_key = auditor_assumed_credentials.secret_access_key
+    @permissions_auditor_session_token = auditor_assumed_credentials.session_token
+  end
+
+  sts_client = Aws::STS::Client.new(
+    region: ENV.fetch('BOSH_AWS_REGION', 'us-west-1'),
+    access_key_id: ENV.fetch('BOSH_AWS_ACCESS_KEY_ID'),
+    secret_access_key: ENV.fetch('BOSH_AWS_SECRET_ACCESS_KEY'),
+    session_token: ENV.fetch('BOSH_AWS_SESSION_TOKEN', nil)
+  )
+  assumed_creds = sts_client.assume_role(
+    {
+      role_arn: ENV.fetch('BOSH_AWS_ROLE_ARN', nil),
+      role_session_name: 'rsn' + '-' + SecureRandom.uuid
+    }
+  ).credentials
+
+  @access_key_id = assumed_creds.access_key_id
+  @secret_access_key = assumed_creds.secret_access_key
+  @session_token = assumed_creds.session_token
 end
 
 RSpec.configure do |rspec_config|
   include IntegrationHelpers
-
   rspec_config.before(:all) do
-    @access_key_id                  = ENV.fetch('BOSH_AWS_ACCESS_KEY_ID')
-    @secret_access_key              = ENV.fetch('BOSH_AWS_SECRET_ACCESS_KEY')
-    @session_token                  = ENV.fetch('BOSH_AWS_SESSION_TOKEN', nil)
-    @subnet_id                      = ENV.fetch('BOSH_AWS_SUBNET_ID')
-    @subnet_zone                    = ENV.fetch('BOSH_AWS_SUBNET_ZONE')
-    @kms_key_arn                    = ENV.fetch('BOSH_AWS_KMS_KEY_ARN')
-    @kms_key_arn_override           = ENV.fetch('BOSH_AWS_KMS_KEY_ARN_OVERRIDE')
-    @region                         = ENV.fetch('BOSH_AWS_REGION', 'us-west-1')
-    @default_key_name               = ENV.fetch('BOSH_AWS_DEFAULT_KEY_NAME', 'bosh')
-    @ami                            = ENV.fetch('BOSH_AWS_IMAGE_ID', 'ami-866d3ee6')
-    @permissions_auditor_key_id     = ENV.fetch('BOSH_AWS_PERMISSIONS_AUDITOR_KEY_ID', nil)
-    @permissions_auditor_secret_key = ENV.fetch('BOSH_AWS_PERMISSIONS_AUDITOR_SECRET_KEY', nil)
+    set_assume_role_permissions
 
-    @cpi_api_version                = ENV.fetch('BOSH_AWS_CPI_API_VERSION', 1).to_i
+    @subnet_id = ENV.fetch('BOSH_AWS_SUBNET_ID')
+    @subnet_zone = ENV.fetch('BOSH_AWS_SUBNET_ZONE')
+    @kms_key_arn = ENV.fetch('BOSH_AWS_KMS_KEY_ARN')
+    @kms_key_arn_override = ENV.fetch('BOSH_AWS_KMS_KEY_ARN_OVERRIDE')
+    @region = ENV.fetch('BOSH_AWS_REGION', 'us-west-1')
+    @default_key_name = ENV.fetch('BOSH_AWS_DEFAULT_KEY_NAME', 'bosh')
+    @ami = ENV.fetch('BOSH_AWS_IMAGE_ID', 'ami-866d3ee6')
+
+    @cpi_api_version = ENV.fetch('BOSH_AWS_CPI_API_VERSION', 1).to_i
 
     logger = Bosh::Cpi::Logger.new(STDERR)
     Bosh::Clouds::Config.define_singleton_method(:logger) { logger }
@@ -80,6 +118,8 @@ RSpec.configure do |rspec_config|
   end
 
   rspec_config.before(:each) do
+    set_assume_role_permissions
+
     @registry = instance_double(Bosh::Cpi::RegistryClient).as_null_object
     allow(Bosh::Cpi::RegistryClient).to receive(:new).and_return(@registry)
     allow(@registry).to receive(:read_settings).and_return({})
@@ -92,6 +132,7 @@ RSpec.configure do |rspec_config|
         'fast_path_delete' => 'yes',
         'access_key_id' => @access_key_id,
         'secret_access_key' => @secret_access_key,
+        'role_arn' => @role_arn,
         'session_token' => @session_token,
         'max_retries' => 8
       },
@@ -100,9 +141,9 @@ RSpec.configure do |rspec_config|
         'user' => 'fake',
         'password' => 'fake'
       },
-      'debug'=> {
-        'cpi'=> {
-          'api_version'=> MOCK_CPI_API_VERSION
+      'debug' => {
+        'cpi' => {
+          'api_version' => MOCK_CPI_API_VERSION
         },
       },
     }
@@ -157,7 +198,6 @@ def vm_lifecycle(vm_disks: disks, ami_id: ami, cpi: @cpi)
 
   cpi.set_vm_metadata(instance_id, vm_metadata)
 
-
   yield(instance_id) if block_given?
 ensure
   cpi.delete_vm(instance_id) if instance_id
@@ -175,7 +215,6 @@ def get_root_block_device(root_device_name, block_devices)
     root_device_name.start_with?(device.device_name)
   end
 end
-
 
 def get_target_group_arn(name)
   elb_v2_client.describe_target_groups(names: [name]).target_groups[0].target_group_arn

--- a/src/bosh_aws_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -57,6 +57,7 @@ describe 'cpi.json.erb' do
             'default_key_name'=>nil,
             'default_security_groups'=>['security_group_1'],
             'region' => 'moon',
+            'role_arn' => nil,
             'max_retries' => 8,
             'encrypted' => false,
             'kms_key_arn' => nil,


### PR DESCRIPTION
The CPI will use assume role authentication if a role_arn is specified by the user in the cpi.json file.
Also, the integration tests, bats and e2e tests now use an assumed role to work.
The pipeline has changed to reflect this and now include the roles to be assumed.

[#184632801] Add AssumeRole support to bosh-aws-cpi