### PR TITLE
Add an example for aws metadata options

### DIFF
--- a/jobs/aws_cpi/spec
+++ b/jobs/aws_cpi/spec
@@ -74,6 +74,11 @@ properties:
       properties accepted by the ModifyInstanceMetadataOptions endpoint
       (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyInstanceMetadataOptions.html).
       e.g. `http_put_response_hop_limit`.
+      example:
+        aws:
+          metadata_options:
+            http_endpoint: enabled
+            http_tokens: required
     default: null
 
   registry.username:


### PR DESCRIPTION
From the current descrition it wasn't clear what format was expected here (string, array, hash, etc.). This example should make things clearer