### PR TITLE
Fix gem bundle call during packaging

### DIFF
--- a/packages/bosh_aws_cpi/packaging
+++ b/packages/bosh_aws_cpi/packaging
@@ -11,10 +11,6 @@ cp -a bosh_aws_cpi/* ${BOSH_INSTALL_TARGET}
 
 cd ${BOSH_INSTALL_TARGET}
 
-export BUNDLER_VERSION="$(bundle -v | grep -o -e '[0-9.]*')"
-bundle config set --local deployment 'true'
-bundle config set --local no_prune 'true'
-bundle config set --local without 'development test'
 bundle config set --local cache_path 'vendor/package'
 
-bundle install
+bosh_bundle_local


### PR DESCRIPTION
We've seen some failures because it was simply using "bundle install" which does not properly install the gems into BOSH_INSTALL_TARGET.

After upgrading to ruby 3.2 it seems that the gems instead are installed into /usr/local/bundle which does not transfer from the compilation VM into the package so when the CPI is later invoked the gems are missing.

Copied the pattern from the [bosh director packaging script](https://github.com/cloudfoundry/bosh/blob/34d6a88dfae3cd505df72e73d99a2d94b04b0e0a/packages/director/packaging#L45)