### PR TITLE
Use the dualstack support of the aws-sdk to support IPv6

### DIFF
--- a/src/bosh_aws_cpi/lib/cloud/aws/aws_provider.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/aws_provider.rb
@@ -26,7 +26,8 @@ module Bosh::AwsCloud
         credentials: @aws_config.credentials,
         retry_limit: @aws_config.max_retries,
         logger: @logger,
-        log_level: :debug
+        log_level: :debug,
+        use_dualstack_endpoint: true,
       }
       if @aws_config.region
         params[:region] = @aws_config.region

--- a/src/bosh_aws_cpi/spec/unit/aws_provider_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/aws_provider_spec.rb
@@ -13,7 +13,8 @@ describe Bosh::AwsCloud::AwsProvider do
       retry_limit: 8,
       logger: logger,
       log_level: :debug,
-      region: 'us-east-1'
+      region: 'us-east-1',
+      use_dualstack_endpoint: true
     }
   end
   let(:ec2_client) { instance_double(Aws::EC2::Client) }


### PR DESCRIPTION
AWS not support IPv6 with the normal endpoints. They introduced new endpoints: https://docs.aws.amazon.com/ec2/latest/devguide/ec2-endpoints.html

Luckily the AWS-RUBY-SDK already support this endpoint. It's only necessary to set the use_dualstack_endpoint parameter. As this support ipv4 and ipv6, i think we can use this as default.