### PR TITLE
New NVMe instance types

### DIFF
--- a/src/bosh_aws_cpi/lib/cloud/aws/block_device_manager.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/block_device_manager.rb
@@ -5,7 +5,7 @@ module Bosh::AwsCloud
 
     # Newer, nitro-based instances use NVMe storage volumes.
     # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances
-    NVME_INSTANCE_FAMILIES = %w[a1 c5 c5a c5ad c5d c5n c6a c6g c6gd c6gn c6i c6id c6in c7i d3 d3en g4 g5 g4dn i3en i4i inf1 m5 m5a m5ad m5d m5dn m5n m5zn m6a m6g m6gd m6i m6id m6idn m6in m7i m7i-flex p3dn p4 r5 r5a r5ad r5b r5d r5dn r5n r6a r6g r6gd r6i r6in r6id r6idn r7iz t3 t3a t4g z1d x2iezn].freeze
+    NVME_INSTANCE_FAMILIES = %w[a1 c5 c5a c5ad c5d c5n c6a c6g c6gd c6gn c6i c6id c6in c7i d3 d3en g4dn g4ad g5 i3en i4i inf1 m5 m5a m5ad m5d m5dn m5n m5zn m6a m6g m6gd m6i m6id m6idn m6in m7i m7i-flex p3dn p4d p5 r5 r5a r5ad r5b r5d r5dn r5n r6a r6g r6gd r6i r6in r6id r6idn r7iz t3 t3a t4g z1d x2iezn].freeze
 
     def initialize(logger, stemcell, vm_cloud_props)
       @logger = logger


### PR DESCRIPTION
Correcting some instance types that use NVMe (e.g. there is no P4 type, only p4d, there is g4ad and g4dn , also a new p5).  This is for use with the GenAI bosh release.