### PR TITLE
Add a config parameter to enable dualstack if needed

### DIFF
--- a/src/bosh_aws_cpi/lib/cloud/aws/aws_provider.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/aws_provider.rb
@@ -27,7 +27,7 @@ module Bosh::AwsCloud
         retry_limit: @aws_config.max_retries,
         logger: @logger,
         log_level: :debug,
-        use_dualstack_endpoint: true,
+        use_dualstack_endpoint: @aws_config.dualstack,
       }
       if @aws_config.region
         params[:region] = @aws_config.region

--- a/src/bosh_aws_cpi/lib/cloud/aws/config.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/config.rb
@@ -4,6 +4,7 @@ module Bosh::AwsCloud
     attr_reader :region, :ec2_endpoint, :elb_endpoint, :stemcell
     attr_reader :access_key_id, :secret_access_key, :default_key_name, :encrypted, :kms_key_arn
     attr_reader :default_iam_instance_profile, :default_security_groups, :metadata_options
+    attr_reader :dualstack
 
     CREDENTIALS_SOURCE_STATIC = 'static'.freeze
     CREDENTIALS_SOURCE_ENV_OR_PROFILE = 'env_or_profile'.freeze
@@ -13,6 +14,7 @@ module Bosh::AwsCloud
       @config = aws_config_hash
 
       @max_retries = @config['max_retries']
+      @dualstack = @config['dualstack']
 
       @region = @config['region']
       @ec2_endpoint = @config['ec2_endpoint']

--- a/src/bosh_aws_cpi/spec/integration/aws_cpi_spec.rb
+++ b/src/bosh_aws_cpi/spec/integration/aws_cpi_spec.rb
@@ -24,7 +24,8 @@ describe 'the aws_cpi executable' do
             'region' => @region,
             'default_key_name' => 'default_key_name',
             'fast_path_delete' => 'yes',
-            'max_retries' => 0
+            'max_retries' => 0,
+            'dualstack' => false
           },
           'registry' => {
             'endpoint' => 'fake',

--- a/src/bosh_aws_cpi/spec/spec_helper.rb
+++ b/src/bosh_aws_cpi/spec/spec_helper.rb
@@ -19,7 +19,8 @@ def mock_cloud_options
         'default_key_name' => 'sesame',
         'default_security_groups' => [],
         'max_retries' => 8,
-        'source_dest_check' => false
+        'source_dest_check' => false,
+        'dualstack' => false
       },
       'registry' => {
         'endpoint' => 'localhost:42288',

--- a/src/bosh_aws_cpi/spec/unit/aws_provider_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/aws_provider_spec.rb
@@ -14,7 +14,7 @@ describe Bosh::AwsCloud::AwsProvider do
       logger: logger,
       log_level: :debug,
       region: 'us-east-1',
-      use_dualstack_endpoint: true
+      use_dualstack_endpoint: false
     }
   end
   let(:ec2_client) { instance_double(Aws::EC2::Client) }

--- a/src/bosh_aws_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -54,7 +54,8 @@ describe 'cpi.json.erb' do
             'max_retries' => 8,
             'encrypted' => false,
             'kms_key_arn' => nil,
-            'metadata_options' => nil
+            'metadata_options' => nil,
+            'dualstack' => false
           },
           'registry' => {
             'endpoint' => 'http://admin:admin@registry-host.example.com:25777',
@@ -167,6 +168,16 @@ describe 'cpi.json.erb' do
 
     it 'overrides the default value' do
       expect(subject['cloud']['properties']['aws']['credentials_source']).to eq('custom')
+    end
+  end
+
+  context 'enable dualstack to use different api endpoints' do
+    before do
+      manifest['properties']['aws']['dualstack'] = true
+    end
+
+    it 'overrides the default value' do
+      expect(subject['cloud']['properties']['aws']['dualstack']).to eq(true)
     end
   end
 


### PR DESCRIPTION
Based on https://github.com/cloudfoundry/bosh-aws-cpi-release/pull/163, i added a config parameter to enable this feature.