### PR TITLE
Allow use of assumed roles through role_arn when using credentials_source: env_or_profile

### DIFF
--- a/jobs/aws_cpi/spec
+++ b/jobs/aws_cpi/spec
@@ -27,7 +27,7 @@ properties:
     description: AWS session_token when using STS credentials for the aws cpi (Optional, used when aws.credentials_source is set to `static`)
     default: null
   aws.role_arn:
-    description: AWS role_arn to be assumed by the CPI when authenticating (Optional, used when aws.credentials_source is set to `static`)
+    description: AWS role_arn to be assumed by the CPI when authenticating (Optional)
     default: null
   aws.default_iam_instance_profile:
     description: Default AWS iam_instance_profile for the aws cpi

--- a/src/bosh_aws_cpi/spec/unit/config_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/config_spec.rb
@@ -154,6 +154,23 @@ describe Bosh::AwsCloud::Config do
       config = Bosh::AwsCloud::Config.build(options)
       expect(config.aws.credentials).to be_a(env_prof_creds.class)
     end
+
+    context 'when role_arn is sent' do
+      before do
+        options['aws']['role_arn'] = 'arn:aws:iam::123456789012:role/role_name'
+        options['aws']['session_token'] = nil
+      end
+
+      it 'should use the AssumeRoleCredentials' do
+        allow(Aws::InstanceProfileCredentials).to receive(:new).and_return(env_prof_creds)
+        allow(Aws::STS::Client).to receive(:new).and_return(sts_client)
+        allow(Aws::AssumeRoleCredentials).to receive(:new).and_return(assume_role_creds)
+
+        config = Bosh::AwsCloud::Config.build(options)
+
+        expect(config.aws.credentials).to be_a(assume_role_creds.class)
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Currently, `role_arn` is only used when `credentials_source: static` is configured, allowing the use of an assumed role. This change extends the functionality to also support `credentials_source: env_or_profile` in combination with `role_arn`.

This would, for instance, allow the creation of a bosh director, even if the director VM will not reside in the same AWS account to which the creating VM's instance profile belongs.