### PR TITLE
enable aws allocated ipv6 prefix

### DIFF
--- a/src/bosh_aws_cpi/lib/cloud/aws/cloud_core.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/cloud_core.rb
@@ -85,6 +85,11 @@ module Bosh::AwsCloud
         if environment && environment['bosh'] && environment['bosh']['tags']
           tags = environment['bosh']['tags']
         end
+
+        if environment && environment['ipv6_prefix_delegation_size']
+          ipv6_prefix_delegation_size = environment['ipv6_prefix_delegation_size']
+        end
+
         # TODO IMDS_V2
         instance = @instance_manager.create(
           stemcell.image_id,
@@ -95,6 +100,7 @@ module Bosh::AwsCloud
           block_device_mappings,
           settings.encode(@stemcell_api_version),
           tags,
+          ipv6_prefix_delegation_size, 
           @config.aws.metadata_options
         )
 

--- a/src/bosh_aws_cpi/lib/cloud/aws/instance.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/instance.rb
@@ -114,6 +114,10 @@ module Bosh::AwsCloud
       @aws_instance.exists? && @aws_instance.state.name != 'terminated'
     end
 
+    def network_interface_id
+      @aws_instance.network_interfaces[0].network_interface_id
+    end
+
     def update_routing_tables(route_definitions)
       if route_definitions.length > 0
         @logger.debug('Associating instance with destinations in the routing tables')

--- a/src/bosh_aws_cpi/lib/cloud/aws/instance_manager.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/instance_manager.rb
@@ -15,7 +15,7 @@ module Bosh::AwsCloud
       @param_mapper = InstanceParamMapper.new(security_group_mapper, logger)
     end
 
-    def create(stemcell_id, vm_cloud_props, networks_cloud_props, disk_locality, default_security_groups, block_device_mappings, user_data, tags, metadata_options)
+    def create(stemcell_id, vm_cloud_props, networks_cloud_props, disk_locality, default_security_groups, block_device_mappings, user_data, tags, ipv6_prefix_delegation_size, metadata_options)
       abruptly_terminated_retries = 2
       begin
         instance_params = build_instance_params(
@@ -40,8 +40,7 @@ module Bosh::AwsCloud
 
         aws_instance = create_aws_instance(instance_params, vm_cloud_props)
         instance = Bosh::AwsCloud::Instance.new(aws_instance, @logger)
-
-        babysit_instance_creation(instance, vm_cloud_props)
+        babysit_instance_creation(instance, vm_cloud_props, ipv6_prefix_delegation_size)
       rescue => e
         if e.is_a?(Bosh::AwsCloud::AbruptlyTerminated)
           @logger.warn("Failed to configure instance '#{instance.id}': #{e.inspect}")
@@ -63,7 +62,7 @@ module Bosh::AwsCloud
 
     private
 
-    def babysit_instance_creation(instance, vm_cloud_props)
+    def babysit_instance_creation(instance, vm_cloud_props, ipv6_prefix_delegation_size)
       begin
         # We need to wait here for the instance to be running, as if we are going to
         # attach to a load balancer, the instance must be running.
@@ -71,6 +70,7 @@ module Bosh::AwsCloud
         instance.wait_until_running
         instance.update_routing_tables(vm_cloud_props.advertised_routes)
         instance.disable_dest_check unless vm_cloud_props.source_dest_check
+        attach_ipv6_prefixes(instance, ipv6_prefix_delegation_size)
       rescue => e
         if e.is_a?(Bosh::AwsCloud::AbruptlyTerminated)
           raise
@@ -83,6 +83,15 @@ module Bosh::AwsCloud
           end
           raise
         end
+      end
+    end
+
+    def attach_ipv6_prefixes(instance, ipv6_prefix_delegation_size)
+      unless ipv6_prefix_delegation_size.nil?
+        @ec2.client.assign_ipv_6_addresses(
+          network_interface_id: instance.network_interface_id,
+          ipv_6_prefix_count: 1 # aws only supports /80 prefixes
+        )
       end
     end
 

--- a/src/bosh_aws_cpi/spec/unit/cloud_core_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/cloud_core_spec.rb
@@ -135,7 +135,7 @@ describe Bosh::AwsCloud::CloudCore do
       }
 
       it 'passes instance metadata to AWS' do
-        expect(instance_manager).to receive(:create).with(anything,anything,anything,anything,anything,anything,anything,anything,metadata_options).and_return(instance)
+        expect(instance_manager).to receive(:create).with(anything,anything,anything,anything,anything,anything,anything,anything,anything,metadata_options).and_return(instance)
 
         cloud.create_vm('foo', 'stemcell_id', 'vm_type', double('network_props', {filter: []}), settings)
       end
@@ -143,7 +143,7 @@ describe Bosh::AwsCloud::CloudCore do
     context 'when instance metadata is not set in cpi config' do
 
       it 'passes instance metadata to AWS' do
-        expect(instance_manager).to receive(:create).with(anything,anything,anything,anything,anything,anything,anything,anything,nil).and_return(instance)
+        expect(instance_manager).to receive(:create).with(anything,anything,anything,anything,anything,anything,anything,anything,anything,nil).and_return(instance)
         expect(options['aws']).to_not have_key('metadata_options')
 
         cloud.create_vm('foo', 'stemcell_id', 'vm_type', double('network_props', {filter: []}), settings)

--- a/src/bosh_aws_cpi/spec/unit/create_vm_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/create_vm_spec.rb
@@ -34,7 +34,8 @@ describe Bosh::AwsCloud::CloudCore, 'create_vm' do
         'group' => '',
         'groups' => [],
         'tags' => {'tag' => 'tag_value'},
-      }
+      },
+      'ipv6_prefix_delegation_size' => '80',
     }
   end
   let(:stemcell) {instance_double(Bosh::AwsCloud::Stemcell, root_device_name: 'root name', image_id: stemcell_id)}
@@ -102,6 +103,7 @@ describe Bosh::AwsCloud::CloudCore, 'create_vm' do
       anything,
       anything,
       anything,
+      anything,
       anything
     ).and_return(instance)
     expect(cloud.create_vm(agent_id, stemcell_id, vm_type, networks_cloud_props, agent_settings, disk_locality, environment)).to eq(['fake-id', networks_cloud_props])
@@ -122,6 +124,7 @@ describe Bosh::AwsCloud::CloudCore, 'create_vm' do
       anything,
       anything,
       'my encoded settings',
+      anything,
       anything,
       anything
     ).and_return(instance)
@@ -147,6 +150,23 @@ describe Bosh::AwsCloud::CloudCore, 'create_vm' do
       anything,
       anything,
       { 'tag' => 'tag_value' },
+      anything,
+      anything
+    )
+    cloud.create_vm(agent_id, stemcell_id, vm_type, networks_cloud_props, agent_settings, disk_locality, environment)
+  end
+
+  it 'should include the ipv6_prefix_delegation_size from the environment' do
+    expect(instance_manager).to receive(:create).with(
+      anything,
+      anything,
+      anything,
+      anything,
+      anything,
+      anything,
+      anything,
+      anything,
+      '80',
       anything
     )
     cloud.create_vm(agent_id, stemcell_id, vm_type, networks_cloud_props, agent_settings, disk_locality, environment)

--- a/src/bosh_aws_cpi/spec/unit/instance_manager_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/instance_manager_spec.rb
@@ -83,6 +83,13 @@ module Bosh::AwsCloud
         fake_instance_params.merge(min_count: 1, max_count: 1)
       end
       let(:tags) { {'tag' => 'tag_value'} }
+      let(:ipv6_prefix_delegation_size) { nil }
+      let(:attach_ipv6_prefix_params) do
+        {
+          network_interface_id: '1',
+          ipv_6_prefix_count: 1
+        }
+      end
 
       before do
         allow(param_mapper).to receive(:instance_params).and_return(fake_instance_params)
@@ -133,6 +140,7 @@ module Bosh::AwsCloud
             fake_block_device_mappings,
             user_data,
             tags,
+            ipv6_prefix_delegation_size,
             nil
           )
         end
@@ -151,8 +159,33 @@ module Bosh::AwsCloud
           fake_block_device_mappings,
           user_data,
           tags,
+          ipv6_prefix_delegation_size,
           nil
         )
+      end
+
+      context 'when ipv6_prefix_delegation_size is provided' do
+        let(:ipv6_prefix_delegation_size) { '80' }
+
+        it 'should ask AWS to attach an ipv6 prefix' do
+          allow(instance).to receive(:network_interface_id).and_return('1')
+          allow(instance_manager).to receive(:get_created_instance_id).with('run-instances-response').and_return('i-12345678')
+
+          expect(aws_client).to receive(:run_instances).with(run_instances_params).and_return('run-instances-response')
+          expect(aws_client).to receive(:assign_ipv_6_addresses).with(attach_ipv6_prefix_params)
+          instance_manager.create(
+            stemcell_id,
+            vm_cloud_props,
+            networks_cloud_props,
+            disk_locality,
+            default_options,
+            fake_block_device_mappings,
+            user_data,
+            tags,
+            ipv6_prefix_delegation_size,
+            nil
+          )
+        end
       end
 
       context 'redacts' do
@@ -170,6 +203,7 @@ module Bosh::AwsCloud
             fake_block_device_mappings,
             user_data,
             tags,
+            ipv6_prefix_delegation_size,
             nil
           )
         end
@@ -244,6 +278,7 @@ module Bosh::AwsCloud
             fake_block_device_mappings,
             user_data,
             tags,
+            ipv6_prefix_delegation_size,
             nil
           )
         end
@@ -263,6 +298,7 @@ module Bosh::AwsCloud
                 fake_block_device_mappings,
                 user_data,
                 tags,
+                ipv6_prefix_delegation_size,
                 nil
               )
             }.to raise_error(Bosh::Clouds::VMCreationFailed, /Spot instance creation failed/)
@@ -300,6 +336,7 @@ module Bosh::AwsCloud
                 fake_block_device_mappings,
                 user_data,
                 tags,
+                ipv6_prefix_delegation_size,
                 nil
               )
             end
@@ -319,6 +356,7 @@ module Bosh::AwsCloud
                 fake_block_device_mappings,
                 user_data,
                 tags,
+                ipv6_prefix_delegation_size,
                 nil
               )
             end
@@ -344,6 +382,7 @@ module Bosh::AwsCloud
             fake_block_device_mappings,
             user_data,
             tags,
+            ipv6_prefix_delegation_size,
             nil
           )
         end
@@ -370,6 +409,7 @@ module Bosh::AwsCloud
             fake_block_device_mappings,
             user_data,
             tags,
+            ipv6_prefix_delegation_size,
             nil
           )
         end
@@ -397,6 +437,7 @@ module Bosh::AwsCloud
           fake_block_device_mappings,
           user_data,
           tags,
+          ipv6_prefix_delegation_size,
           nil
         )
       end
@@ -425,6 +466,7 @@ module Bosh::AwsCloud
               fake_block_device_mappings,
               user_data,
               tags,
+              ipv6_prefix_delegation_size,
               nil
             )
           }.to raise_error(create_err)
@@ -450,6 +492,7 @@ module Bosh::AwsCloud
               fake_block_device_mappings,
               user_data,
               tags,
+              ipv6_prefix_delegation_size,
               nil
             )
           }.to raise_error(Bosh::AwsCloud::AbruptlyTerminated)
@@ -474,6 +517,7 @@ module Bosh::AwsCloud
                 fake_block_device_mappings,
                 user_data,
                 tags,
+                ipv6_prefix_delegation_size,
                 nil
               )
             }.to raise_error(create_err)


### PR DESCRIPTION
This PR introduces new property ipv6_prefix_delegation_size that can be defined in the environment. This will tell aws to attach an aws-allocated ipv6 prefix to the vm additionally to the single ips attached to the vms during creation.

Related to: https://github.com/sap-contributions/cf-community/blob/rfc-ipv6-in-cf/toc/rfc/rfc-draft-ipv6-dual-stack-for-cf.md 

To let aws attach an ipv6 prefix the following configuration would need to be done in the instance_groups section:
```
instance_groups:
  name: diego_cells
  instances: 2
  env:
    ipv6_prefix_delegation_size: 80 (AWS supports only /80)
    bosh: 
      ipv6:
        enable: true
```
