### PR TITLE
Update debug API version to 3 and fix AMI tagging logic

### DIFF
--- a/jobs/aws_cpi/templates/cpi.json.erb
+++ b/jobs/aws_cpi/templates/cpi.json.erb
@@ -36,7 +36,7 @@ end
 
 params["cloud"]["properties"]["debug"] = {
   'cpi'=> {
-    'api_version'=> p('debug.cpi.api_version', 2)
+    'api_version'=> p('debug.cpi.api_version', 3)
   },
 }
 

--- a/src/bosh_aws_cpi/lib/cloud/aws/cloud_v3.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/cloud_v3.rb
@@ -73,13 +73,20 @@ module Bosh::AwsCloud
 
           "#{available_image.id} light"
         else
-          stemcell = create_ami_for_stemcell(image_path, props)
+          stemcell_id = create_ami_for_stemcell(image_path, props)
 
           if !tags.nil?
-            TagManager.create_tags(stemcell.ami, tags)
-          end
+            created_ami = @ec2_resource.images(
+              filters: [{
+                          name: "image-id",
+                          values: [stemcell_id],
+                        }]
+              ).first
 
-          stemcell.id
+            TagManager.create_tags(created_ami, tags)
+          end
+          logger.info("Tagged #{stemcell_id} with #{tags}.")
+          stemcell_id
         end
       end
     end

--- a/src/bosh_aws_cpi/lib/cloud/aws/config.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/config.rb
@@ -117,7 +117,7 @@ module Bosh::AwsCloud
   end
 
   class Config
-    MAX_SUPPORTED_API_VERSION = 2
+    MAX_SUPPORTED_API_VERSION = 3
 
     attr_reader :aws, :registry, :agent, :stemcell_api_version
 

--- a/src/bosh_aws_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -5,7 +5,7 @@ require 'ostruct'
 
 describe 'cpi.json.erb' do
   let(:cpi_specification_file) { File.absolute_path(File.join(jobs_root, 'aws_cpi/spec')) }
-  let(:cpi_api_version) { 2 }
+  let(:cpi_api_version) { 3 }
 
   subject(:parsed_json) do
     context_hash = YAML.load_file(cpi_specification_file)

--- a/src/bosh_aws_cpi/spec/unit/cloud_v3_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/cloud_v3_spec.rb
@@ -242,7 +242,12 @@ describe Bosh::AwsCloud::CloudV3 do
       end
       let(:cloud) {
         mock_cloud_v3 do |ec2|
-          allow(ec2).to receive(:images).and_return([image])
+          allow(ec2).to receive(:images).with(
+            filters: [{
+                        name: "image-id",
+                        values: [ami_id],
+                      }]
+          ).and_return([image])
         end
       }
       let(:aws_config) do
@@ -253,8 +258,7 @@ describe Bosh::AwsCloud::CloudV3 do
       let(:props_factory) { instance_double(Bosh::AwsCloud::PropsFactory) }
 
       before do
-        stemcell = Bosh::AwsCloud::Stemcell.new(nil, image)
-        allow(cloud).to receive(:create_ami_for_stemcell).and_return(stemcell)
+        allow(cloud).to receive(:create_ami_for_stemcell).and_return(ami_id)
       end
 
       it "if tags are provided" do

--- a/src/bosh_aws_cpi/spec/unit/cloud_v3_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/cloud_v3_spec.rb
@@ -240,7 +240,11 @@ describe Bosh::AwsCloud::CloudV3 do
           "virtualization_type" => "paravirtual",
         }
       end
-      let(:cloud) { mock_cloud_v3 }
+      let(:cloud) {
+        mock_cloud_v3 do |ec2|
+          allow(ec2).to receive(:images).and_return([image])
+        end
+      }
       let(:aws_config) do
         instance_double(Bosh::AwsCloud::AwsConfig, stemcell: {}, encrypted: false, kms_key_arn: nil)
       end


### PR DESCRIPTION
Fixes the logic for tagging ami images on stemcell creation and bumps up the debug.cpi.api_version default value and MAX_SUPPORTED_API_VERSION to 3.
Follow up PR for [Apply tags on stemcell creation](https://github.com/cloudfoundry/bosh-aws-cpi-release/pull/177)
