### PR TITLE
CI: Move BATS director internal_ip out of AWS-reserved low IP range

### DIFF
--- a/ci/assets/terraform/template.tf
+++ b/ci/assets/terraform/template.tf
@@ -311,7 +311,7 @@ output "dns_recursor_ip" {
   value = cidrhost(aws_vpc.default.cidr_block, 2)
 }
 output "internal_ip" {
-  value = cidrhost(aws_vpc.default.cidr_block, 6)
+  value = cidrhost(aws_vpc.default.cidr_block, 10)
 }
 output "reserved_range" {
   value = "${cidrhost(aws_vpc.default.cidr_block, 2)}-${cidrhost(aws_vpc.default.cidr_block, 9)}"

--- a/ci/assets/terraform/template.tf
+++ b/ci/assets/terraform/template.tf
@@ -314,10 +314,10 @@ output "internal_ip" {
   value = cidrhost(aws_vpc.default.cidr_block, 10)
 }
 output "reserved_range" {
-  value = "${cidrhost(aws_vpc.default.cidr_block, 2)}-${cidrhost(aws_vpc.default.cidr_block, 9)}"
+  value = "${cidrhost(aws_vpc.default.cidr_block, 2)}-${cidrhost(aws_vpc.default.cidr_block, 10)}"
 }
 output "static_range" {
-  value = "${cidrhost(aws_vpc.default.cidr_block, 10)}-${cidrhost(aws_vpc.default.cidr_block, 30)}"
+  value = "${cidrhost(aws_vpc.default.cidr_block, 11)}-${cidrhost(aws_vpc.default.cidr_block, 30)}"
 }
 output "bats_eip" {
   value = aws_eip.deployment.public_ip


### PR DESCRIPTION
Looked into [this failure](https://bosh.ci.cloudfoundry.org/teams/main/pipelines/bosh-aws-cpi/jobs/bats/builds/277) with AI. Here is the current hypothesis after pushing back on gemini and then giving that to claude code:

> 10.0.0.6 falls inside the same low subnet range (10.0.0.2-9) that AWS assigns ENIs to for the ELB/ALB created by this  same template, causing an intermittent InvalidIPAddressInUse failure when creating the director VM (e.g. build bosh-aws-cpi/bats/277). Moving it to 10.0.0.10, inside the already-documented static_range, avoids the collision.

Upon interrogation, AI couldn't come up with any explicit doc claiming that low subnet range, so this reasoning seems to be inferred from [this post](https://repost.aws/questions/QUzUQiheNRS8-6rKwE_adUJg/max-number-of-ip-free-ip-per-subnet-for-multiple-alb) and the fact that:
* AWS reserves the first 4 addresses of any subnet
* ELB/ALB/NLB consume additional IPs from the low end of the remaining pool as they scale

Trying this out here, bats passed: https://bosh.ci.cloudfoundry.org/teams/main/pipelines/test-delete-when-finished-fix-bats-collisions